### PR TITLE
fix(auth): keep stored refresh_token when Google omits it on re-login

### DIFF
--- a/search_console_webapp/database.py
+++ b/search_console_webapp/database.py
@@ -574,11 +574,19 @@ def create_or_update_oauth_connection(user_id: int, google_account_id: str, goog
 
         if existing:
             connection_id = existing['id']
+            # NOTE (2026-05-19): Google only returns a refresh_token on the FIRST
+            # authorization (or when prompt=consent is forced). On every subsequent
+            # login, creds['refresh_token'] is None. The previous code wrote that
+            # None straight into refresh_token_encrypted, which violated the
+            # NOT NULL constraint and made the whole login fail with
+            # "null value in column refresh_token_encrypted ...".
+            # Fix: COALESCE — if no new refresh_token arrives, keep the stored one
+            # (the old refresh_token is still valid).
             cur.execute('''
                 UPDATE oauth_connections
                 SET google_email = %s,
                     access_token = %s,
-                    refresh_token_encrypted = %s,
+                    refresh_token_encrypted = COALESCE(%s, refresh_token_encrypted),
                     token_uri = %s,
                     client_id = %s,
                     client_secret = %s,


### PR DESCRIPTION
## Summary

Fixes the recurring `null value in column "refresh_token_encrypted" violates not-null constraint` error that breaks Google login on every re-authentication.

## Root cause

Google returns a `refresh_token` only on the **first** OAuth authorization (or with forced `prompt=consent`). On subsequent logins it's `None`. `create_or_update_oauth_connection` wrote that `None` into `refresh_token_encrypted = NULL` in the UPDATE → NOT NULL violation → whole upsert failed → user saw `auth_error=user_not_found`.

## Fix

- UPDATE now uses `refresh_token_encrypted = COALESCE(%s, refresh_token_encrypted)` — keeps the existing (still-valid) token when no new one arrives.
- `oauth_connections.refresh_token_encrypted` column changed NOT NULL → NULLABLE (`ALTER TABLE ... DROP NOT NULL` already applied to production) as defense for the rare brand-new-INSERT-without-token case.

## Verification

- `python3 -m ast` → SYNTAX_OK
- Production check: 0 existing rows had NULL (the old bug failed the entire UPDATE, so it never persisted corrupt data)

## Test plan
- [ ] Deploy succeeds
- [ ] Log out + log back in with Google → no `auth_error`, no constraint error in logs
- [ ] `oauth_connections` row keeps its refresh_token after re-login

🤖 Generated with [Claude Code](https://claude.com/claude-code)