### PR TITLE
fix(auth): global 401 fetch interceptor — auto-redirect to login on session expiry

### DIFF
--- a/search_console_webapp/static/js/session-manager.js
+++ b/search_console_webapp/static/js/session-manager.js
@@ -39,6 +39,71 @@ class SessionManager {
         this.startSessionChecking();
         this.startKeepAlive();
         this.createWarningModal();
+        this.installFetchInterceptor();
+    }
+
+    /**
+     * Instala un interceptor global sobre window.fetch que detecta respuestas 401
+     * (sesión expirada / no autenticado) procedentes de CUALQUIER endpoint y dispara
+     * handleSessionExpired automáticamente.
+     *
+     * Sin este interceptor, módulos como LLM Monitoring, Manual AI, etc. cada uno
+     * tendría que detectar el 401 en cada uno de sus 30+ fetch() y redirigir al
+     * login — y en la práctica no lo hacen, así que el usuario ve "Failed to load"
+     * en vez de un redirect limpio cuando expira la sesión por inactividad.
+     *
+     * Solo actúa cuando el body del 401 contiene flags de auth (session_expired,
+     * auth_required o un error message tipo "Authentication required"). Esto evita
+     * tocar 401 de OTROS dominios (p. ej. APIs externas) o 401 que la app maneje
+     * intencionadamente con su propia lógica.
+     */
+    installFetchInterceptor() {
+        if (typeof window === 'undefined' || !window.fetch) return;
+        if (window.__sessionManagerFetchPatched) return;  // idempotente
+        window.__sessionManagerFetchPatched = true;
+
+        const originalFetch = window.fetch.bind(window);
+        const self = this;
+        let handlingExpired = false;
+
+        window.fetch = async function (...args) {
+            const response = await originalFetch(...args);
+
+            if (response.status === 401 && !handlingExpired) {
+                // Clonar para no consumir el body original (el caller lo necesita)
+                let payload = null;
+                try {
+                    payload = await response.clone().json();
+                } catch (_) {
+                    payload = null;
+                }
+
+                const looksLikeAuthExpiry =
+                    payload &&
+                    (
+                        payload.session_expired === true ||
+                        payload.auth_required === true ||
+                        (typeof payload.error === 'string' &&
+                            /authentication|session expired|user not found/i.test(payload.error))
+                    );
+
+                if (looksLikeAuthExpiry) {
+                    handlingExpired = true;
+                    try {
+                        self.handleSessionExpired(payload);
+                    } catch (e) {
+                        // Si por la razón que sea handleSessionExpired falla,
+                        // forzar redirect manual como último recurso.
+                        try { window.location.href = '/login?session_expired=true'; }
+                        catch (_) { /* noop */ }
+                    }
+                }
+            }
+
+            return response;
+        };
+
+        this.log('Global 401 fetch interceptor installed');
     }
 
     /**


### PR DESCRIPTION
## Summary

User reported: opening a project in LLM Monitoring returns 401 with a generic "Failed to load project" instead of redirecting to login.

## Root cause

`SESSION_TIMEOUT_MINUTES=45` (auth.py). When the user leaves a tab open >45 min, the backend session expires by inactivity. Subsequent `fetch()` calls return 401 with `{session_expired: true}`. But the 39+ fetch handlers across the codebase only do:

```javascript
if (!response.ok) { throw new Error(`HTTP ${response.status}`); }
```

so the user sees "Failed to load" instead of a redirect. `SessionManager` polls `/auth/status` but the user can hit a 401 between polls — exactly what happens here.

## Fix

`SessionManager.init()` now installs a **global** `window.fetch` interceptor that:
- Inspects every response
- On `status===401` with an auth-expiry flag (`session_expired` / `auth_required` / error mentioning "authentication"/"session"), calls `handleSessionExpired(payload)` → toast + redirect to `/login?session_expired=true`
- Is idempotent (`window.__sessionManagerFetchPatched`)
- Clones the response before reading so the original caller still gets an intact response
- Leaves untouched: non-401 codes, plain 401 without auth flags, 402/403/404/500

## Why this approach

- Universal: fixes LLM Monitoring + Manual AI + AI Mode + admin etc. with one change
- Surface area: +65 lines, zero modifications to existing code
- No backend changes
- No risk to other modules (only acts on auth-expiry-shape 401s)

## Test plan
- [ ] Deploy
- [ ] Leave a tab open >45 min, try to open a project → should redirect to /login?session_expired=true (not show "Failed to load")
- [ ] Active sessions: all flows continue to work normally (no false redirects)
- [ ] Plans 402 paywall flow still works (interceptor ignores 402)

🤖 Generated with [Claude Code](https://claude.com/claude-code)