### PR TITLE
fix(llm): bump Perplexity test_connection max_tokens (root cause of 19-may Perplexity gap)

### DIFF
--- a/search_console_webapp/services/llm_providers/perplexity_provider.py
+++ b/search_console_webapp/services/llm_providers/perplexity_provider.py
@@ -252,11 +252,19 @@ class PerplexityProvider(BaseLLMProvider):
         Verifica que la API key funcione
         """
         try:
-            # Test simple con query mínima
+            # Test simple con query mínima.
+            # NOTA (2026-05-21): Perplexity cambió la API entre 2026-05-16 y
+            # 2026-05-19 y ahora rechaza max_tokens < 16 con HTTP 400
+            # ("max_tokens must be at least 16 for sonar"). El valor anterior
+            # (10) hacía que test_connection fallase SIEMPRE, lo que provocaba
+            # que analyze_project excluyese Perplexity de TODOS los proyectos
+            # en cada run (visto en producción el 2026-05-19: 0 rows de
+            # Perplexity, mientras los otros 3 LLMs generaron 137 cada uno).
+            # 20 da un poco de margen por si Perplexity vuelve a subir el mínimo.
             response = self.client.chat.completions.create(
                 model=self.model,
                 messages=[{"role": "user", "content": "Hi"}],
-                max_tokens=10
+                max_tokens=20
             )
             
             if response and response.choices:


### PR DESCRIPTION
## Root cause

Cron LLM del 2026-05-19: Perplexity quedó con 0 rows mientras OpenAI/Anthropic/Google generaron 137 cada uno. **No fue un outage de Perplexity** — fue un cambio de su API que rechaza ahora `max_tokens < 16`.

Nuestro `test_connection()` pedía `max_tokens=10` → siempre 400 → `analyze_project` siempre excluía Perplexity como provider no sano → 0 rows.

`execute_query()` siempre funcionó (usa `max_tokens=16000`), por eso el bug nunca tocó la lógica de negocio — solo el health-check.

**Sin este fix, el próximo cron (vie 22 may) generará otro día sin Perplexity**, indefinidamente.

## Fix

`max_tokens=10` → `max_tokens=20` (mínimo 16 + margen).

## Validación

```
$ PerplexityProvider().test_connection()
ERROR: max_tokens must be at least 16 for sonar  ← ANTES
✅ OK  ← DESPUÉS
```

## Test plan
- [ ] Deploy
- [ ] Comprobar logs del próximo cron (vie 22 may 04:00 UTC) — Perplexity debe volver
- [ ] (manual) Disparar /api/llm-monitoring/cron/daily-analysis con un proyecto y verificar que se generan 4 LLMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)