### PR TITLE
fix(llm): Gemini 3.5 Flash + resiliencia health-check + alerta provider-missing

### DIFF
--- a/search_console_webapp/cron_alerts.py
+++ b/search_console_webapp/cron_alerts.py
@@ -161,6 +161,116 @@ def _check_cost_spike(get_db_connection_fn, multiplier: float) -> Optional[Dict]
                 pass
 
 
+def _check_provider_coverage(run: Dict, get_db_connection_fn) -> Optional[Dict]:
+    """
+    Alert si algún LLM HABILITADO no devolvió NINGÚN resultado durante el run.
+
+    Cubre el fallo silencioso en el que un provider se excluye en el health-check
+    (o cae/agota cuota por completo) y desaparece del análisis sin contar como
+    'fallo de proyecto' — exactamente el caso del outage de Gemini de may-2026,
+    en el que Google estuvo a 0 resultados durante varios runs sin que ninguna
+    alerta se disparara.
+
+    Por cada proyecto que produjo filas en la ventana del run, compara los
+    providers habilitados (enabled_llms) contra los que realmente devolvieron
+    filas. Funciona para CUALQUIER provider (OpenAI / Anthropic / Google /
+    Perplexity).
+    """
+    started = run.get('started_at')
+    completed = run.get('completed_at')
+    if not started or not completed:
+        return None
+    conn = None
+    try:
+        conn = get_db_connection_fn()
+        if conn is None:
+            return None
+        cur = conn.cursor()
+        cur.execute("""
+            WITH ran AS (
+                SELECT DISTINCT project_id
+                FROM llm_monitoring_results
+                WHERE created_at >= %s AND created_at <= %s
+            ),
+            expected AS (
+                SELECT p.id AS project_id, p.name AS project_name,
+                       UNNEST(p.enabled_llms) AS provider
+                FROM llm_monitoring_projects p
+                JOIN ran r ON r.project_id = p.id
+            ),
+            got AS (
+                SELECT project_id, llm_provider, COUNT(*) AS n
+                FROM llm_monitoring_results
+                WHERE created_at >= %s AND created_at <= %s
+                GROUP BY project_id, llm_provider
+            )
+            SELECT e.provider, e.project_id, e.project_name
+            FROM expected e
+            LEFT JOIN got g
+              ON g.project_id = e.project_id AND g.llm_provider = e.provider
+            WHERE COALESCE(g.n, 0) = 0
+            ORDER BY e.provider, e.project_id
+        """, (started, completed, started, completed))
+        rows = cur.fetchall() or []
+        if not rows:
+            return None
+
+        from collections import defaultdict
+        missing = defaultdict(list)
+        for r in rows:
+            if isinstance(r, dict):
+                prov, pid, pname = r.get('provider'), r.get('project_id'), r.get('project_name')
+            else:
+                prov, pid, pname = r[0], r[1], r[2]
+            missing[prov].append(pname or f'#{pid}')
+
+        # Total de proyectos que corrieron (para calcular severidad)
+        cur.execute("""
+            SELECT COUNT(DISTINCT project_id)
+            FROM llm_monitoring_results
+            WHERE created_at >= %s AND created_at <= %s
+        """, (started, completed))
+        rr = cur.fetchone()
+        if isinstance(rr, dict):
+            total_ran = (list(rr.values())[0] if rr else 0) or 0
+        else:
+            total_ran = (rr[0] if rr else 0) or 0
+
+        parts = []
+        global_outage = False
+        for prov, projects in sorted(missing.items()):
+            parts.append(f"{prov} (faltó en {len(projects)}/{total_ran} proyectos)")
+            if total_ran and len(projects) >= total_ran:
+                global_outage = True
+
+        return {
+            'type': 'provider_missing',
+            'severity': 'high' if global_outage else 'medium',
+            'metric': '; '.join(parts),
+            'threshold': '0 resultados',
+            'message': (
+                'Uno o más LLMs habilitados no devolvieron ningún resultado en este run: '
+                + '; '.join(parts) + '. '
+                'Posible health-check fallido, API caída, cuota agotada o modelo retirado. '
+                'Revisa los logs del provider y el modelo is_current en llm_model_registry.'
+            ),
+        }
+    except Exception as e:
+        logger.warning(f"[cron_alerts] provider-coverage check skipped: {e}")
+        if conn:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+        return None
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
 # ---------------------------------------------------------------------------
 # Email rendering and sending
 # ---------------------------------------------------------------------------
@@ -324,6 +434,12 @@ def check_and_send_cron_alerts(run_id: int, get_db_connection_fn=None) -> Dict:
         if a: alerts.append(a)
     except Exception as e:
         logger.warning(f"[cron_alerts] cost-spike check failed: {e}")
+
+    try:
+        a = _check_provider_coverage(run, get_db_connection_fn)
+        if a: alerts.append(a)
+    except Exception as e:
+        logger.warning(f"[cron_alerts] provider-coverage check failed: {e}")
 
     if not alerts:
         logger.info(f"[cron_alerts] run {run_id}: no thresholds breached")
@@ -651,6 +767,11 @@ def send_run_completion_email(run_id: int, get_db_connection_fn=None) -> Dict:
         if a: alerts.append(a)
     except Exception as e:
         logger.warning(f"[cron_alerts] cost-spike check failed: {e}")
+    try:
+        a = _check_provider_coverage(run, get_db_connection_fn)
+        if a: alerts.append(a)
+    except Exception as e:
+        logger.warning(f"[cron_alerts] provider-coverage check failed: {e}")
 
     run_cost = _load_run_cost(run, get_db_connection_fn)
     errors = _load_top_errors(run, get_db_connection_fn, limit=10)

--- a/search_console_webapp/database.py
+++ b/search_console_webapp/database.py
@@ -436,22 +436,27 @@ def init_database():
         cur.execute('CREATE INDEX IF NOT EXISTS idx_analysis_runs_status ON llm_monitoring_analysis_runs(status)')
         cur.execute('CREATE INDEX IF NOT EXISTS idx_analysis_runs_started ON llm_monitoring_analysis_runs(started_at DESC)')
 
-        # ── Migración: Google → Gemini 3 Flash (2026-03-04) ──
-        # Asegurar que gemini-3-flash-preview exista y sea el modelo current
+        # ── Migración: Google → Gemini 3.5 Flash (2026-06-01) ──
+        # Asegurar que gemini-3.5-flash exista y sea el modelo current.
+        # Sustituye a gemini-3-flash-preview: ese modelo 'preview' es efímero y
+        # Google lo capó/limitó ~22-26 may 2026, lo que dejó a Gemini fuera del
+        # análisis diario de todos los proyectos sin previo aviso. 3.5-flash es
+        # un modelo estable y soportado para generateContent.
         cur.execute("""
             INSERT INTO llm_model_registry (
                 llm_provider, model_id, model_display_name,
                 cost_per_1m_input_tokens, cost_per_1m_output_tokens,
-                is_current, is_available
+                is_current, is_available, pending_approval
             ) VALUES (
-                'google', 'gemini-3-flash-preview', 'Gemini 3 Flash',
-                0.50, 3.00, FALSE, TRUE
+                'google', 'gemini-3.5-flash', 'Gemini 3.5 Flash',
+                0.50, 3.00, FALSE, TRUE, FALSE
             )
             ON CONFLICT (llm_provider, model_id) DO UPDATE SET
-                model_display_name = 'Gemini 3 Flash',
+                model_display_name = 'Gemini 3.5 Flash',
                 cost_per_1m_input_tokens = 0.50,
                 cost_per_1m_output_tokens = 3.00,
                 is_available = TRUE,
+                pending_approval = FALSE,
                 updated_at = NOW()
         """)
         # Quitar is_current de todos los modelos Google
@@ -460,13 +465,13 @@ def init_database():
             SET is_current = FALSE, updated_at = NOW()
             WHERE llm_provider = 'google'
         """)
-        # Marcar Flash como current
+        # Marcar Gemini 3.5 Flash como current
         cur.execute("""
             UPDATE llm_model_registry
             SET is_current = TRUE, updated_at = NOW()
-            WHERE llm_provider = 'google' AND model_id = 'gemini-3-flash-preview'
+            WHERE llm_provider = 'google' AND model_id = 'gemini-3.5-flash'
         """)
-        logger.info("✅ Google model migrado a gemini-3-flash-preview")
+        logger.info("✅ Google model current = gemini-3.5-flash")
 
         # ── Admin Audit Log ──
         cur.execute('''

--- a/search_console_webapp/database.py
+++ b/search_console_webapp/database.py
@@ -442,21 +442,24 @@ def init_database():
         # Google lo capó/limitó ~22-26 may 2026, lo que dejó a Gemini fuera del
         # análisis diario de todos los proyectos sin previo aviso. 3.5-flash es
         # un modelo estable y soportado para generateContent.
+        # NOTA: no referenciar 'pending_approval' aquí. Esa columna la añade la
+        # migración llm_model_discovery_v2 y NO existe en todos los entornos
+        # (p.ej. staging). Tocarla rompe init_database() e impide arrancar la app.
+        # La gestión de pending_approval se hace aparte, donde la columna exista.
         cur.execute("""
             INSERT INTO llm_model_registry (
                 llm_provider, model_id, model_display_name,
                 cost_per_1m_input_tokens, cost_per_1m_output_tokens,
-                is_current, is_available, pending_approval
+                is_current, is_available
             ) VALUES (
                 'google', 'gemini-3.5-flash', 'Gemini 3.5 Flash',
-                0.50, 3.00, FALSE, TRUE, FALSE
+                0.50, 3.00, FALSE, TRUE
             )
             ON CONFLICT (llm_provider, model_id) DO UPDATE SET
                 model_display_name = 'Gemini 3.5 Flash',
                 cost_per_1m_input_tokens = 0.50,
                 cost_per_1m_output_tokens = 3.00,
                 is_available = TRUE,
-                pending_approval = FALSE,
                 updated_at = NOW()
         """)
         # Quitar is_current de todos los modelos Google

--- a/search_console_webapp/services/llm_monitoring_service.py
+++ b/search_console_webapp/services/llm_monitoring_service.py
@@ -1222,13 +1222,20 @@ JSON:"""
             # Filtrar LLMs activos
             enabled_llms = project['enabled_llms'] or []
             active_providers = {
-                name: provider 
+                name: provider
                 for name, provider in self.providers.items()
                 if name in enabled_llms
             }
-            
+
             if len(active_providers) == 0:
                 raise Exception("No hay proveedores LLM habilitados para este proyecto")
+
+            # Conjunto de providers que SE ESPERABA ejecutar (habilitados ∩
+            # instanciados), capturado ANTES del health-check. Se usa abajo para
+            # detectar providers que terminan con 0 resultados (p.ej. excluidos
+            # por el health-check) — que de otro modo desaparecerían del run sin
+            # contar como "incompletos" ni disparar la reconciliación.
+            expected_provider_names = list(active_providers.keys())
             
             logger.info(f"   🤖 {len(active_providers)} proveedores habilitados")
             logger.info("")
@@ -1312,17 +1319,30 @@ JSON:"""
 
                 if not health_ok:
                     unhealthy_providers.append(name)
-                    logger.error(f"   ⚠️  Este provider será EXCLUIDO del análisis")
-            
-            # Usar solo providers saludables
-            active_providers = healthy_providers
-            
+
+            # ── Política de exclusión por health-check ──
+            # Por defecto NO excluimos un provider por fallar el health-check
+            # ligero. El "Hi" con timeout corto puede fallar puntualmente bajo
+            # carga aunque el provider funcione, y excluirlo borra el provider
+            # entero del run de forma silenciosa (causa del outage de Gemini de
+            # may-2026). Las 5 capas de retry sobre las queries reales decidirán,
+            # y cualquier fallo persistente quedará como filas de error visibles.
+            # Comportamiento estricto opcional: LLM_HEALTHCHECK_EXCLUDE_ON_FAIL=true
+            exclude_on_fail = os.getenv('LLM_HEALTHCHECK_EXCLUDE_ON_FAIL', 'false').lower() == 'true'
+            if unhealthy_providers and exclude_on_fail:
+                active_providers = healthy_providers
+                logger.warning(f"⚠️  Excluidos del análisis (health-check estricto): {', '.join(unhealthy_providers)}")
+            elif unhealthy_providers:
+                logger.warning(f"⚠️  Health-check falló para: {', '.join(unhealthy_providers)}")
+                logger.warning(f"   → NO se excluyen; se intentarán con el sistema de retry en las queries reales")
+            # (si exclude_on_fail=False, active_providers conserva todos los habilitados)
+
             logger.info("")
             logger.info("=" * 70)
             logger.info(f"✅ PROVIDERS SALUDABLES: {len(active_providers)}/{len(enabled_llms)}")
             logger.info("=" * 70)
             logger.info(f"Activos: {', '.join(active_providers.keys())}")
-            if unhealthy_providers:
+            if unhealthy_providers and exclude_on_fail:
                 logger.warning(f"⚠️  Excluidos: {', '.join(unhealthy_providers)}")
                 logger.warning(f"   → El análisis continuará sin estos providers")
             logger.info("")
@@ -1654,10 +1674,16 @@ JSON:"""
             conn.close()
         
         # ✨ NUEVO: Calcular completitud por LLM
+        # Iteramos sobre los providers ESPERADOS (capturados antes del
+        # health-check), no solo sobre los que devolvieron filas. Así un provider
+        # que terminó con 0 resultados (p.ej. excluido por health-check o caído)
+        # cuenta como incompleto (0/N) y la reconciliación (Capa 4) lo reintenta,
+        # en vez de desaparecer silenciosamente del run.
         completeness_by_llm = {}
         incomplete_llms = []
-        
-        for llm_name, llm_results in results_by_llm.items():
+
+        for llm_name in expected_provider_names:
+            llm_results = results_by_llm.get(llm_name, [])
             queries_analyzed = len(llm_results)
             completeness_pct = (queries_analyzed / total_queries_expected * 100) if total_queries_expected > 0 else 0
             completeness_by_llm[llm_name] = {

--- a/search_console_webapp/services/llm_providers/google_provider.py
+++ b/search_console_webapp/services/llm_providers/google_provider.py
@@ -14,6 +14,7 @@ MODEL IDs disponibles:
 Docs: https://ai.google.dev/gemini-api/docs/models
 """
 
+import os
 import logging
 import time
 from typing import Dict, Optional
@@ -56,8 +57,8 @@ class GoogleProvider(BaseLLMProvider):
         else:
             self.model_name = get_current_model_for_provider('google')
             if not self.model_name:
-                self.model_name = 'gemini-3-flash-preview'
-                logger.warning("⚠️ No se encontró modelo actual en BD, usando gemini-3-flash-preview por defecto")
+                self.model_name = 'gemini-3.5-flash'
+                logger.warning("⚠️ No se encontró modelo actual en BD, usando gemini-3.5-flash por defecto")
         
         generation_config = {
             'max_output_tokens': 65536,
@@ -176,6 +177,7 @@ class GoogleProvider(BaseLLMProvider):
     
     def get_model_display_name(self) -> str:
         display_names = {
+            'gemini-3.5-flash': 'Gemini 3.5 Flash',
             'gemini-3-flash-preview': 'Gemini 3 Flash',
             'gemini-3.1-pro-preview': 'Gemini 3.1 Pro',
             'gemini-3-pro-preview': 'Gemini 3 Pro',
@@ -191,9 +193,14 @@ class GoogleProvider(BaseLLMProvider):
         Verifica que la API key funcione
         """
         try:
+            # Gemini 3.x es un modelo "thinking": un "Hi" puede tardar más que un
+            # chat clásico. 15s era demasiado agresivo y, bajo la carga concurrente
+            # del cron, el health-check fallaba y excluía a Google del run entero.
+            # Timeout configurable (default 30s).
+            timeout_s = int(os.getenv('GOOGLE_HEALTHCHECK_TIMEOUT', '30'))
             test_response = self.model.generate_content(
                 "Hi",
-                request_options={"timeout": 15}  # Health check: 15s max
+                request_options={"timeout": timeout_s}
             )
             if test_response and test_response.text:
                 logger.info("✅ Google connection test successful")


### PR DESCRIPTION
Mismo cambio que #63 (mergeado a staging), cherry-pick limpio sobre `main`.

## Contexto
Gemini (Google) llevaba **sin generar resultados desde el 22-may-2026**: el modelo preview `gemini-3-flash-preview` dejó de servir y el health-check excluía a Google del run entero de forma silenciosa (sin error, sin reintento, sin alerta).

## Cambios
- Modelo Google → **`gemini-3.5-flash`** (estable). Migración de arranque + fallback/display. (El `is_current` en la BD de producción ya se cambió manualmente; la migración de arranque lo deja durable.)
- Health-check no excluye por defecto (gate `LLM_HEALTHCHECK_EXCLUDE_ON_FAIL`); timeout Google configurable `GOOGLE_HEALTHCHECK_TIMEOUT` (30s).
- Completitud por LLM sobre providers **esperados** → un provider a 0 cuenta como incompleto y se reintenta en reconciliación.
- Nuevo check de alerta `_check_provider_coverage` (todos los providers) — validado contra runs reales 38/39.

## Verificación
- Re-análisis de Delfín: 4/4 LLMs, Google sobre `gemini-3.5-flash`, 0 errores.
- Desplegado y verificado previamente en staging (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)