### PR TITLE
feat(geo): geo-params AI Mode, no_cache de frescura e idioma por país (LLM Monitoring)

### DIFF
--- a/search_console_webapp/ai_mode_projects/services/analysis_service.py
+++ b/search_console_webapp/ai_mode_projects/services/analysis_service.py
@@ -22,6 +22,12 @@ from ai_mode_projects.services.domains_service import DomainsService
 
 logger = logging.getLogger(__name__)
 
+# Frescura de datos: forzar a SerpAPI a ignorar su caché de servidor para
+# obtener un resultado de AI Mode actual en cada análisis (objetividad por
+# mercado). Configurable por env para poder revertir sin redeploy si el
+# coste en RU lo requiere. Por defecto: activado.
+SERP_NO_CACHE = os.getenv('SERP_NO_CACHE', 'true').strip().lower() in ('1', 'true', 'yes', 'on')
+
 # Lazy imports para evitar problemas de orden
 try:
     from services.ai_cache import ai_cache
@@ -339,15 +345,21 @@ class AnalysisService:
         # Fix #7: Unified location map — use country_config.py (70+ countries) via ISO-2 conversion
         # instead of hardcoded 32-country map
         internal_code = convert_iso_to_internal_country(country_code)
+        serp_gl = None
+        serp_hl = None
         try:
             from services.country_config import get_country_config
             country_cfg = get_country_config(internal_code)
             if country_cfg:
                 location = country_cfg['serp_location']
+                serp_gl = country_cfg.get('serp_gl')
+                serp_hl = country_cfg.get('serp_hl')
             else:
                 location = 'Madrid, Spain'  # Fallback seguro
+                serp_gl, serp_hl = 'es', 'es'
         except Exception:
             location = 'Madrid, Spain'
+            serp_gl, serp_hl = 'es', 'es'
         
         try:
             # Parámetros para Google AI Mode (google.com/ai)
@@ -357,8 +369,18 @@ class AnalysisService:
                 "location": location,  # Nombre de país/ciudad que SerpApi acepta
                 "api_key": api_key
             }
+            # Geo unificado con AI Overview: gl (país) + hl (idioma) para
+            # resultados consistentes y localizados por mercado.
+            # El engine google_ai_mode admite gl/hl/location/no_cache
+            # (NO google_domain, por eso no se incluye aquí).
+            if serp_gl:
+                params["gl"] = serp_gl
+            if serp_hl:
+                params["hl"] = serp_hl
+            if SERP_NO_CACHE:
+                params["no_cache"] = True
             
-            logger.info(f"🔍 Calling SerpApi Google AI Mode for keyword: '{keyword}' (location: {location})")
+            logger.info(f"🔍 Calling SerpApi Google AI Mode for keyword: '{keyword}' (location: {location}, gl: {serp_gl}, hl: {serp_hl})")
             
             # Hacer la llamada a SerpApi
             search = GoogleSearch(params)

--- a/search_console_webapp/llm_monitoring_routes.py
+++ b/search_console_webapp/llm_monitoring_routes.py
@@ -58,6 +58,7 @@ from services.project_access_service import (
 from database import get_db_connection, acquire_analysis_lock, release_analysis_lock, get_latest_analysis_run
 from services.llm_monitoring_service import MultiLLMMonitoringService, analyze_all_active_projects
 from services.llm_monitoring_stats import LLMMonitoringStatsService
+from services.country_config import get_default_language_for_country
 
 # Configurar logging
 logger = logging.getLogger(__name__)
@@ -634,8 +635,12 @@ def create_project():
     brand_domain = data.get('brand_domain')
     brand_keywords = data.get('brand_keywords', [])
     selected_competitors = data.get('selected_competitors', [])  # ✨ NEW
-    language = str(data.get('language', 'es') or 'es').strip().lower() or 'es'
     country_code = str(data.get('country_code', 'ES') or 'ES').strip().upper()
+    # Idioma de contenido: si el cliente NO lo envía, derivarlo del país
+    # (FR->fr, IT->it, PT->pt...) en vez de asumir 'es'. Si lo envía
+    # explícitamente, se respeta tal cual (sin cambio de comportamiento).
+    _language_in = str(data.get('language') or '').strip().lower()
+    language = _language_in or get_default_language_for_country(country_code)
     enabled_llms = data.get('enabled_llms', ['openai', 'anthropic', 'google', 'perplexity'])
     
     # Validaciones

--- a/search_console_webapp/manual_ai/services/analysis_service.py
+++ b/search_console_webapp/manual_ai/services/analysis_service.py
@@ -22,6 +22,12 @@ from manual_ai.services.domains_service import DomainsService
 
 logger = logging.getLogger(__name__)
 
+# Frescura de datos: forzar a SerpAPI a ignorar su caché de servidor para
+# obtener un SERP/AI Overview actual en cada análisis (objetividad por
+# mercado). Configurable por env para poder revertir sin redeploy si el
+# coste en RU lo requiere. Por defecto: activado.
+SERP_NO_CACHE = os.getenv('SERP_NO_CACHE', 'true').strip().lower() in ('1', 'true', 'yes', 'on')
+
 # Lazy imports para evitar problemas de orden
 try:
     from services.ai_cache import ai_cache
@@ -430,7 +436,9 @@ class AnalysisService:
             'api_key': api_key,
             'num': 20
         }
-        
+        if SERP_NO_CACHE:
+            serp_params_base['no_cache'] = True
+
         country_config = get_country_config(internal_country)
         if country_config:
             serp_params_base.update({
@@ -517,6 +525,8 @@ class AnalysisService:
             'num': 20,
             'page_token': page_token,  # ← única diferencia vs _fetch_serp_data
         }
+        if SERP_NO_CACHE:
+            expanded_params['no_cache'] = True
 
         country_config = get_country_config(internal_country)
         if country_config:

--- a/search_console_webapp/services/country_config.py
+++ b/search_console_webapp/services/country_config.py
@@ -600,3 +600,51 @@ def get_country_flag(gsc_country_code):
     """Obtiene bandera del país"""
     config = get_country_config(gsc_country_code)
     return config['flag'] if config else '🌍'  # Bandera mundial por defecto
+
+
+# ============================================================
+# País (ISO-2) -> idioma de contenido por defecto (ISO 639-1)
+# ============================================================
+# Se usa para auto-rellenar el idioma de un proyecto cuando el cliente no
+# lo especifica (p.ej. creación de proyectos LLM Monitoring), de forma que
+# un proyecto de Francia use 'fr' en vez de asumir 'es'. El idioma elegido
+# es coherente con el 'serp_hl' que cada país usa en COUNTRY_MAPPING, para
+# que LLMs y SERP (AI Overview / AI Mode) hablen el mismo idioma por mercado.
+COUNTRY_TO_LANGUAGE = {
+    # Español
+    'ES': 'es', 'MX': 'es', 'AR': 'es', 'CO': 'es', 'CL': 'es', 'PE': 'es',
+    'VE': 'es', 'EC': 'es', 'UY': 'es', 'PY': 'es', 'BO': 'es', 'GT': 'es',
+    'CR': 'es', 'CU': 'es', 'HN': 'es', 'SV': 'es', 'PA': 'es', 'NI': 'es',
+    'PR': 'es', 'DO': 'es',
+    # Portugués
+    'PT': 'pt', 'BR': 'pt',
+    # Francés (coherente con serp_hl: BE y LU usan 'fr')
+    'FR': 'fr', 'BE': 'fr', 'LU': 'fr', 'MC': 'fr',
+    # Italiano
+    'IT': 'it',
+    # Alemán (coherente con serp_hl: CH y LI usan 'de')
+    'DE': 'de', 'AT': 'de', 'CH': 'de', 'LI': 'de',
+    # Neerlandés
+    'NL': 'nl',
+    # Nórdicos
+    'SE': 'sv', 'DK': 'da', 'NO': 'no', 'FI': 'fi',
+    # Otros europeos
+    'PL': 'pl', 'RO': 'ro', 'GR': 'el',
+    # Inglés
+    'US': 'en', 'GB': 'en', 'IE': 'en', 'CA': 'en', 'AU': 'en', 'NZ': 'en',
+    'IN': 'en', 'SG': 'en', 'ZA': 'en', 'AE': 'en',
+    # Otros mercados
+    'TR': 'tr', 'IL': 'he', 'SA': 'ar', 'JP': 'ja', 'CN': 'zh', 'KR': 'ko',
+    'ID': 'id', 'TH': 'th', 'RU': 'ru',
+}
+
+
+def get_default_language_for_country(country_code, fallback='es'):
+    """Idioma de contenido por defecto (ISO 639-1) para un país ISO-2.
+
+    Devuelve `fallback` ('es' por compatibilidad histórica con el
+    comportamiento previo) si el país no está mapeado o no se proporciona.
+    """
+    if not country_code:
+        return fallback
+    return COUNTRY_TO_LANGUAGE.get(str(country_code).strip().upper(), fallback)


### PR DESCRIPTION
## Qué hace

Mejoras de **objetividad de datos por país** en los subsistemas de monitorización, aisladas y de bajo riesgo.

1. **AI Mode** (`ai_mode_projects/services/analysis_service.py`): se envían `gl` (país) + `hl` (idioma) a SerpApi junto a `location`. Antes solo iba `location`, lo que dejaba el idioma/mercado a criterio de SerpApi. Ahora queda **unificado con AI Overview**. (El engine `google_ai_mode` no admite `google_domain`, por eso no se incluye.)

2. **no_cache (frescura)** en AI Mode y AI Overview (`manual_ai/services/analysis_service.py`): se añade `no_cache=true` para forzar un SERP/AI Mode **fresco** en cada análisis y evitar resultados cacheados por SerpApi. Es **configurable** vía env `SERP_NO_CACHE` (default ON) → reversible sin redeploy si el coste en RU lo requiere.

3. **Idioma por país en LLM Monitoring** (`llm_monitoring_routes.py` + nuevo helper en `services/country_config.py`): al crear un proyecto, si el cliente **no** envía idioma, se deriva del país (FR→fr, IT→it, PT→pt…) en vez de asumir `es`. Si el cliente envía idioma explícito, se respeta tal cual.

## Por qué es seguro / no rompe nada

- El `no_cache` se aplica **solo** en los paths de análisis de los dos subsistemas; **no** se toca el `quota_middleware` global ni los screenshots → el resto de llamadas SERP siguen igual.
- El default de idioma **solo** actúa cuando el cliente no envía idioma (cero regresión en el flujo actual). Fallback `es` para países no mapeados = comportamiento previo.
- Rama creada **desde `origin/main`** y con un único cambio (cherry-pick), sin arrastrar commits ajenos.
- `py_compile` OK en los 4 ficheros; helper país→idioma probado (PT/ES/FR/IT) y parsing del flag verificado.
- Ya desplegado y disponible para validar en **staging** (mismo cambio).

## Ficheros
- `ai_mode_projects/services/analysis_service.py`
- `manual_ai/services/analysis_service.py`
- `services/country_config.py` (nuevo `get_default_language_for_country`)
- `llm_monitoring_routes.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)