### PR TITLE
feat(manual-ai): modal "See historic" — comparación histórica de AI Overview

### DIFF
--- a/search_console_webapp/manual_ai/routes/results.py
+++ b/search_console_webapp/manual_ai/routes/results.py
@@ -315,3 +315,42 @@ def get_aio_vs_organic_comparison(project_id):
     except Exception as e:
         logger.error(f"Error computing AIO vs Organic comparison for project {project_id}: {e}")
         return jsonify({'success': False, 'error': 'Internal server error'}), 500
+
+
+@manual_ai_bp.route('/api/projects/<int:project_id>/ai-overview-historical', methods=['GET'])
+@auth_required
+def get_ai_overview_historical(project_id):
+    """
+    Comparación histórica de AI Overview: presencia en el primer vs el último
+    análisis disponibles dentro de la ventana de `days` días, para el dominio
+    del proyecto y cada competidor (keywords ganadas / perdidas / mantenidas con
+    sus URLs afectadas).
+
+    Reutiliza datos ya almacenados (manual_ai_results + manual_ai_global_domains)
+    → cero coste SerpAPI extra.
+
+    Args:
+        project_id: ID del proyecto
+
+    Query params:
+        days: Número de días hacia atrás (default: 30)
+
+    Returns:
+        JSON con {success, data: {comparison_available, compared_dates, entities, ...}}
+    """
+    user = get_current_user()
+
+    if not project_service.user_owns_project(user['id'], project_id):
+        return jsonify({'success': False, 'error': 'Unauthorized'}), 403
+
+    try:
+        days = int(request.args.get('days', DEFAULT_DAYS_RANGE))
+        data = stats_service.get_ai_overview_historical_comparison(project_id, days)
+
+        return jsonify({
+            'success': True,
+            'data': data
+        })
+    except Exception as e:
+        logger.error(f"Error computing AI Overview historical comparison for project {project_id}: {e}")
+        return jsonify({'success': False, 'error': 'Internal server error'}), 500

--- a/search_console_webapp/manual_ai/services/_statistics/historical.py
+++ b/search_console_webapp/manual_ai/services/_statistics/historical.py
@@ -51,6 +51,17 @@ def _domains_match(detected: str, competitor: str) -> bool:
     )
 
 
+def _keep_best(bucket: Dict[int, Dict], keyword_id: int, position, url) -> None:
+    """Guarda en bucket[keyword_id] la MEJOR (menor) posición vista para esa
+    keyword en una fecha, junto a su URL. Una keyword puede aparecer varias
+    veces en global_domains; nos quedamos con la cita mejor posicionada."""
+    existing = bucket.get(keyword_id)
+    if existing is None or (
+        position is not None and (existing['position'] is None or position < existing['position'])
+    ):
+        bucket[keyword_id] = {'position': position, 'url': url}
+
+
 class _HistoricalMixin:
 
     @staticmethod
@@ -164,15 +175,6 @@ class _HistoricalMixin:
         for r in results_rows:
             kw_text[r['keyword_id']] = r['keyword']
 
-        # Dominio propio: mención autoritativa (results) por fecha -> {kw_id: position}
-        proj_mention: Dict[str, Dict[int, Optional[int]]] = {fd: {}, ld: {}}
-        for r in results_rows:
-            dstr = str(r['analysis_date'])
-            if r['domain_mentioned'] and dstr in proj_mention:
-                proj_mention[dstr][r['keyword_id']] = r['domain_position']
-
-        # URL del dominio propio por (fecha, kw_id) desde global_domains (mejor posición)
-        proj_url: Dict[tuple, Dict] = {}
         # Competidores normalizados (preservando el original para mostrar)
         comp_list = []
         seen_norm = set()
@@ -182,7 +184,9 @@ class _HistoricalMixin:
                 seen_norm.add(cn)
                 comp_list.append((cn, c))
 
-        # comp_data[norm][fecha][kw_id] = {'position', 'url'}
+        # Todas las entidades usan la misma forma: {fecha: {kw_id: {position, url}}}.
+        # Dominio propio (URLs) y competidores salen de global_domains.
+        proj_url = {fd: {}, ld: {}}
         comp_data = {cn: {fd: {}, ld: {}} for cn, _ in comp_list}
 
         for g in gd_rows:
@@ -190,56 +194,57 @@ class _HistoricalMixin:
             if dstr not in (fd, ld):
                 continue
             det = _normalize_domain(g['detected_domain'])
-            kid = g['keyword_id']
-            pos = g['domain_position']
-            url = g['domain_source_url']
+            kid, pos, url = g['keyword_id'], g['domain_position'], g['domain_source_url']
 
             if g['is_project_domain']:
-                key = (dstr, kid)
-                existing = proj_url.get(key)
-                if existing is None or (
-                    pos is not None and (existing['position'] is None or pos < existing['position'])
-                ):
-                    proj_url[key] = {'url': url, 'position': pos}
+                _keep_best(proj_url[dstr], kid, pos, url)
 
             for cn, _orig in comp_list:
                 if _domains_match(det, cn):
-                    bucket = comp_data[cn][dstr]
-                    existing = bucket.get(kid)
-                    if existing is None or (
-                        pos is not None and (existing['position'] is None or pos < existing['position'])
-                    ):
-                        bucket[kid] = {'position': pos, 'url': url}
+                    _keep_best(comp_data[cn][dstr], kid, pos, url)
 
-        def _build_entity(label, domain, dtype, prev_map, curr_map, url_lookup) -> Dict:
-            prev_ids = set(prev_map.keys())
-            curr_ids = set(curr_map.keys())
+        # Dominio propio: pertenencia y posición AUTORITATIVAS desde results
+        # (domain_mentioned); la URL se toma de global_domains (is_project_domain).
+        proj_data = {fd: {}, ld: {}}
+        for r in results_rows:
+            dstr = str(r['analysis_date'])
+            if r['domain_mentioned'] and dstr in proj_data:
+                kid = r['keyword_id']
+                proj_data[dstr][kid] = {
+                    'position': r['domain_position'],
+                    'url': (proj_url[dstr].get(kid) or {}).get('url'),
+                }
+
+        def _build_entity(label, domain, dtype, prev_map, curr_map) -> Dict:
+            """prev_map / curr_map: {kw_id: {'position', 'url'}} en cada fecha."""
+            prev_ids = set(prev_map)
+            curr_ids = set(curr_map)
             gained_ids = curr_ids - prev_ids
             lost_ids = prev_ids - curr_ids
             kept_ids = prev_ids & curr_ids
 
             gained = [{
                 'keyword': kw_text.get(kid, ''),
-                'position': curr_map[kid],
-                'url': url_lookup(ld, kid),
+                'position': curr_map[kid]['position'],
+                'url': curr_map[kid]['url'],
             } for kid in gained_ids]
 
             lost = [{
                 'keyword': kw_text.get(kid, ''),
-                'previous_position': prev_map[kid],
-                'previous_url': url_lookup(fd, kid),
+                'previous_position': prev_map[kid]['position'],
+                'previous_url': prev_map[kid]['url'],
             } for kid in lost_ids]
 
             maintained = []
             for kid in kept_ids:
-                pp, cp = prev_map[kid], curr_map[kid]
+                pp, cp = prev_map[kid]['position'], curr_map[kid]['position']
                 delta = (cp - pp) if (pp is not None and cp is not None) else None
                 maintained.append({
                     'keyword': kw_text.get(kid, ''),
                     'previous_position': pp,
                     'current_position': cp,
                     'position_delta': delta,  # negativo = mejora (sube en el ranking)
-                    'url': url_lookup(ld, kid),
+                    'url': curr_map[kid]['url'],
                 })
 
             gained.sort(key=lambda x: (x['position'] is None, x['position'] or 0, x['keyword']))
@@ -262,28 +267,13 @@ class _HistoricalMixin:
                 'maintained': maintained,
             }
 
-        entities: List[Dict] = []
-
-        # Entidad: tu dominio
-        entities.append(_build_entity(
-            'Your domain', project_domain, 'project',
-            proj_mention[fd], proj_mention[ld],
-            lambda dstr, kid: (proj_url.get((dstr, kid)) or {}).get('url'),
-        ))
-
-        # Entidades: cada competidor
+        entities: List[Dict] = [
+            _build_entity('Your domain', project_domain, 'project', proj_data[fd], proj_data[ld])
+        ]
         for cn, orig in comp_list:
-            prev_map = {kid: v['position'] for kid, v in comp_data[cn][fd].items()}
-            curr_map = {kid: v['position'] for kid, v in comp_data[cn][ld].items()}
-
-            def _make_lookup(_cn):
-                def _lookup(dstr, kid):
-                    return (comp_data[_cn][dstr].get(kid) or {}).get('url')
-                return _lookup
-
-            entities.append(_build_entity(
-                orig, orig, 'competitor', prev_map, curr_map, _make_lookup(cn),
-            ))
+            entities.append(
+                _build_entity(orig, orig, 'competitor', comp_data[cn][fd], comp_data[cn][ld])
+            )
 
         return {
             'comparison_available': True,

--- a/search_console_webapp/manual_ai/services/_statistics/historical.py
+++ b/search_console_webapp/manual_ai/services/_statistics/historical.py
@@ -1,0 +1,299 @@
+"""
+Comparación histórica de AI Overview para Manual AI.
+
+Responde a la pregunta de negocio: "Hace N días estas keywords me mencionaban
+en AI Overview, hoy estas otras. ¿En cuáles he ganado/perdido visibilidad y qué
+URLs están afectadas?" — tanto para el dominio del proyecto como para cada
+competidor seleccionado.
+
+No requiere cambios de esquema: reutiliza `manual_ai_results`
+(estado autoritativo del dominio del proyecto) y `manual_ai_global_domains`
+(URLs y presencia de competidores) ya almacenados por el análisis diario.
+
+Estrategia de fechas: como los análisis no corren a diario (p.ej. Lun/Jue/Sáb),
+una fecha exacta "hace 30 días" puede no tener snapshot. Por eso comparamos el
+PRIMER análisis disponible dentro de la ventana contra el ÚLTIMO, y devolvemos
+las fechas reales usadas para que el frontend las muestre con transparencia.
+"""
+
+import logging
+import re
+from datetime import date, timedelta
+from typing import Dict, List, Optional
+from database import get_db_connection
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_domain(value: Optional[str]) -> str:
+    """Normaliza un dominio a comparable: minúsculas, sin esquema, sin www, sin path."""
+    if not value:
+        return ''
+    d = value.strip().lower()
+    d = re.sub(r'^https?://', '', d)
+    d = re.sub(r'^www\.', '', d)
+    d = d.split('/')[0]
+    return d
+
+
+def _domains_match(detected: str, competitor: str) -> bool:
+    """True si `detected` (ya normalizado) corresponde al `competitor` (normalizado).
+
+    Acepta igualdad exacta o relación de subdominio en cualquier dirección, de
+    forma coherente con cómo el resto del sistema empareja competidores.
+    """
+    if not detected or not competitor:
+        return False
+    return (
+        detected == competitor
+        or detected.endswith('.' + competitor)
+        or competitor.endswith('.' + detected)
+    )
+
+
+class _HistoricalMixin:
+
+    @staticmethod
+    def get_ai_overview_historical_comparison(project_id: int, days: int = 30) -> Dict:
+        """
+        Compara la presencia en AI Overview entre el primer y el último análisis
+        disponibles dentro de la ventana de `days` días.
+
+        Args:
+            project_id: ID del proyecto
+            days: Tamaño de la ventana (7 / 30 / 90 ...)
+
+        Returns:
+            Dict con:
+              - comparison_available: bool (False si no hay 2 fechas que comparar)
+              - days, date_range, compared_dates, date_count, project_domain
+              - entities: lista (tu dominio + cada competidor) con summary y
+                listas gained / lost / maintained (cada item con keyword + URL).
+        """
+        empty: Dict = {
+            'comparison_available': False,
+            'days': days,
+            'date_range': {'requested_start': '', 'requested_end': ''},
+            'compared_dates': {'previous': None, 'current': None},
+            'date_count': 0,
+            'project_domain': None,
+            'entities': [],
+        }
+
+        conn = get_db_connection()
+        if not conn:
+            logger.error(f"get_ai_overview_historical_comparison({project_id}): no DB connection")
+            return empty
+
+        try:
+            cur = conn.cursor()
+
+            end_date = date.today()
+            start_date = end_date - timedelta(days=days)
+            empty['date_range'] = {
+                'requested_start': str(start_date),
+                'requested_end': str(end_date),
+            }
+
+            # Proyecto: dominio propio + competidores
+            cur.execute("""
+                SELECT domain, selected_competitors
+                FROM manual_ai_projects
+                WHERE id = %s
+            """, (project_id,))
+            project_row = cur.fetchone()
+            if not project_row:
+                return empty
+
+            project_domain = project_row['domain']
+            competitors = project_row['selected_competitors'] or []
+            empty['project_domain'] = project_domain
+
+            # Endpoints: primera y última fecha de análisis dentro de la ventana
+            cur.execute("""
+                SELECT MIN(analysis_date) AS first_date,
+                       MAX(analysis_date) AS last_date,
+                       COUNT(DISTINCT analysis_date) AS date_count
+                FROM manual_ai_results
+                WHERE project_id = %s
+                    AND analysis_date >= %s AND analysis_date <= %s
+            """, (project_id, start_date, end_date))
+            dates_row = cur.fetchone()
+            first_date = dates_row['first_date']
+            last_date = dates_row['last_date']
+            date_count = dates_row['date_count'] or 0
+
+            # Necesitamos dos fechas distintas para comparar
+            if not first_date or not last_date or first_date == last_date:
+                empty['compared_dates'] = {
+                    'previous': str(first_date) if first_date else None,
+                    'current': str(last_date) if last_date else None,
+                }
+                empty['date_count'] = date_count
+                return empty
+
+            # Resultados de las dos fechas: estado autoritativo del dominio propio
+            cur.execute("""
+                SELECT keyword_id, keyword, analysis_date,
+                       domain_mentioned, domain_position
+                FROM manual_ai_results
+                WHERE project_id = %s
+                    AND analysis_date IN (%s, %s)
+            """, (project_id, first_date, last_date))
+            results_rows = cur.fetchall()
+
+            # Dominios globales de las dos fechas: URLs + presencia de competidores
+            cur.execute("""
+                SELECT keyword_id, analysis_date, detected_domain,
+                       domain_position, domain_source_url, is_project_domain
+                FROM manual_ai_global_domains
+                WHERE project_id = %s
+                    AND analysis_date IN (%s, %s)
+            """, (project_id, first_date, last_date))
+            gd_rows = cur.fetchall()
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+        fd, ld = str(first_date), str(last_date)
+
+        # keyword_id -> texto de keyword
+        kw_text: Dict[int, str] = {}
+        for r in results_rows:
+            kw_text[r['keyword_id']] = r['keyword']
+
+        # Dominio propio: mención autoritativa (results) por fecha -> {kw_id: position}
+        proj_mention: Dict[str, Dict[int, Optional[int]]] = {fd: {}, ld: {}}
+        for r in results_rows:
+            dstr = str(r['analysis_date'])
+            if r['domain_mentioned'] and dstr in proj_mention:
+                proj_mention[dstr][r['keyword_id']] = r['domain_position']
+
+        # URL del dominio propio por (fecha, kw_id) desde global_domains (mejor posición)
+        proj_url: Dict[tuple, Dict] = {}
+        # Competidores normalizados (preservando el original para mostrar)
+        comp_list = []
+        seen_norm = set()
+        for c in competitors:
+            cn = _normalize_domain(c)
+            if cn and cn not in seen_norm:
+                seen_norm.add(cn)
+                comp_list.append((cn, c))
+
+        # comp_data[norm][fecha][kw_id] = {'position', 'url'}
+        comp_data = {cn: {fd: {}, ld: {}} for cn, _ in comp_list}
+
+        for g in gd_rows:
+            dstr = str(g['analysis_date'])
+            if dstr not in (fd, ld):
+                continue
+            det = _normalize_domain(g['detected_domain'])
+            kid = g['keyword_id']
+            pos = g['domain_position']
+            url = g['domain_source_url']
+
+            if g['is_project_domain']:
+                key = (dstr, kid)
+                existing = proj_url.get(key)
+                if existing is None or (
+                    pos is not None and (existing['position'] is None or pos < existing['position'])
+                ):
+                    proj_url[key] = {'url': url, 'position': pos}
+
+            for cn, _orig in comp_list:
+                if _domains_match(det, cn):
+                    bucket = comp_data[cn][dstr]
+                    existing = bucket.get(kid)
+                    if existing is None or (
+                        pos is not None and (existing['position'] is None or pos < existing['position'])
+                    ):
+                        bucket[kid] = {'position': pos, 'url': url}
+
+        def _build_entity(label, domain, dtype, prev_map, curr_map, url_lookup) -> Dict:
+            prev_ids = set(prev_map.keys())
+            curr_ids = set(curr_map.keys())
+            gained_ids = curr_ids - prev_ids
+            lost_ids = prev_ids - curr_ids
+            kept_ids = prev_ids & curr_ids
+
+            gained = [{
+                'keyword': kw_text.get(kid, ''),
+                'position': curr_map[kid],
+                'url': url_lookup(ld, kid),
+            } for kid in gained_ids]
+
+            lost = [{
+                'keyword': kw_text.get(kid, ''),
+                'previous_position': prev_map[kid],
+                'previous_url': url_lookup(fd, kid),
+            } for kid in lost_ids]
+
+            maintained = []
+            for kid in kept_ids:
+                pp, cp = prev_map[kid], curr_map[kid]
+                delta = (cp - pp) if (pp is not None and cp is not None) else None
+                maintained.append({
+                    'keyword': kw_text.get(kid, ''),
+                    'previous_position': pp,
+                    'current_position': cp,
+                    'position_delta': delta,  # negativo = mejora (sube en el ranking)
+                    'url': url_lookup(ld, kid),
+                })
+
+            gained.sort(key=lambda x: (x['position'] is None, x['position'] or 0, x['keyword']))
+            lost.sort(key=lambda x: (x['previous_position'] is None, x['previous_position'] or 0, x['keyword']))
+            maintained.sort(key=lambda x: (x['current_position'] is None, x['current_position'] or 0, x['keyword']))
+
+            return {
+                'type': dtype,
+                'domain': domain,
+                'label': label,
+                'summary': {
+                    'previous_count': len(prev_ids),
+                    'current_count': len(curr_ids),
+                    'gained_count': len(gained_ids),
+                    'lost_count': len(lost_ids),
+                    'maintained_count': len(kept_ids),
+                },
+                'gained': gained,
+                'lost': lost,
+                'maintained': maintained,
+            }
+
+        entities: List[Dict] = []
+
+        # Entidad: tu dominio
+        entities.append(_build_entity(
+            'Your domain', project_domain, 'project',
+            proj_mention[fd], proj_mention[ld],
+            lambda dstr, kid: (proj_url.get((dstr, kid)) or {}).get('url'),
+        ))
+
+        # Entidades: cada competidor
+        for cn, orig in comp_list:
+            prev_map = {kid: v['position'] for kid, v in comp_data[cn][fd].items()}
+            curr_map = {kid: v['position'] for kid, v in comp_data[cn][ld].items()}
+
+            def _make_lookup(_cn):
+                def _lookup(dstr, kid):
+                    return (comp_data[_cn][dstr].get(kid) or {}).get('url')
+                return _lookup
+
+            entities.append(_build_entity(
+                orig, orig, 'competitor', prev_map, curr_map, _make_lookup(cn),
+            ))
+
+        return {
+            'comparison_available': True,
+            'days': days,
+            'date_range': {
+                'requested_start': str(start_date),
+                'requested_end': str(end_date),
+            },
+            'compared_dates': {'previous': fd, 'current': ld},
+            'date_count': date_count,
+            'project_domain': project_domain,
+            'entities': entities,
+        }

--- a/search_console_webapp/manual_ai/services/statistics_service.py
+++ b/search_console_webapp/manual_ai/services/statistics_service.py
@@ -13,8 +13,9 @@ from manual_ai.services._statistics.overview import _OverviewMixin
 from manual_ai.services._statistics.keywords import _KeywordsMixin
 from manual_ai.services._statistics.domains import _DomainsMixin
 from manual_ai.services._statistics.aio_organic import _AioOrganicMixin
+from manual_ai.services._statistics.historical import _HistoricalMixin
 
 
-class StatisticsService(_OverviewMixin, _KeywordsMixin, _DomainsMixin, _AioOrganicMixin):
+class StatisticsService(_OverviewMixin, _KeywordsMixin, _DomainsMixin, _AioOrganicMixin, _HistoricalMixin):
     """Servicio para generar estadísticas y métricas de proyectos"""
     pass

--- a/search_console_webapp/scripts_seed_historical_demo.py
+++ b/search_console_webapp/scripts_seed_historical_demo.py
@@ -1,0 +1,253 @@
+"""
+Seed de DEMO para la comparación histórica de AI Overview (solo STAGING).
+
+Crea (idempotente) un proyecto Manual AI autocontenido bajo el owner indicado,
+con keywords, 2 competidores y 7 fechas de análisis repartidas en 90 días, con
+un relato claro de keywords ganadas / perdidas / mantenidas tanto para el
+dominio del proyecto como para los competidores. Rellena manual_ai_results
+(con ai_analysis_data.references_found) y manual_ai_global_domains, de modo que
+TODO el dashboard (charts, rankings, tabla y el nuevo modal "See historic")
+quede poblado.
+
+SEGURIDAD: aborta si el host de la BD parece producción (switchyard). Pensado
+para ejecutarse con la DATABASE_PUBLIC_URL de staging (caboose).
+
+Uso:
+    DATABASE_URL="$STAGING_PUBLIC_URL" python3 scripts_seed_historical_demo.py
+"""
+
+import os
+import re
+import json
+from datetime import date, timedelta
+from urllib.parse import urlparse
+
+import psycopg2
+import psycopg2.extras
+
+OWNER_USER_ID = 5
+PROJECT_NAME = "Demo · Histórico AI Overview"
+PROJECT_DOMAIN = "asana.com"
+COUNTRY = "US"
+COMPETITORS = ["monday.com", "trello.com"]
+
+# Fechas (offset de días hacia atrás desde hoy), de más antigua a más reciente
+TODAY = date.today()
+OFFSETS = [89, 60, 29, 14, 6, 3, 0]
+DATES = [TODAY - timedelta(days=o) for o in OFFSETS]  # index 0..6 (viejo→nuevo)
+
+# Dominios genéricos (no rastreados) para enriquecer rankings de dominios/URLs
+GENERIC = ["g2.com", "wikipedia.org"]
+
+# Perfiles por keyword: posición por fecha (None = no mencionado ese día).
+# Índices alineados con DATES (0=hace 89d ... 6=hoy).
+KEYWORDS = {
+    "best project management software": {
+        "asana.com":  [5, 5, 4, 4, 3, 2, 2],
+        "monday.com": [3, 3, 2, 2, 2, 1, 1],
+        "trello.com": [None]*7,
+        "g2.com":     [1, 1, 1, 1, 1, 3, 3],
+    },
+    "task management tool": {
+        "asana.com":  [2, 2, 3, 4, 5, 6, 6],
+        "monday.com": [None, None, 4, 4, 3, 3, 2],
+        "trello.com": [6, 6, 6, 5, 5, 5, 5],
+    },
+    "agile project tracking": {
+        "asana.com":  [4, 4, 4, 4, 4, 4, 4],
+        "monday.com": [None, None, None, 5, 5, 4, 4],
+        "trello.com": [None]*7,
+        "wikipedia.org": [2, 2, 2, 2, 2, 2, 2],
+    },
+    "team collaboration software": {
+        "asana.com":  [3, 3, 3, None, None, None, None],
+        "monday.com": [5, 5, 4, 4, 3, 3, 3],
+        "trello.com": [None]*7,
+    },
+    "gantt chart online": {
+        "asana.com":  [6, 6, None, None, None, None, None],
+        "monday.com": [None]*7,
+        "trello.com": [2, 2, 2, 3, 3, 3, 3],
+    },
+    "kanban board app": {
+        "asana.com":  [None, None, None, None, 5, 4, 4],
+        "monday.com": [None]*7,
+        "trello.com": [4, 4, 4, 4, 4, 4, 4],
+    },
+    "workflow automation": {
+        "asana.com":  [None, None, None, None, None, None, 3],
+        "monday.com": [2, 2, 2, 2, 2, 2, 2],
+        "trello.com": [None]*7,
+        "g2.com":     [5, 5, 5, 5, 5, 5, 5],
+    },
+    "resource planning tool": {
+        "asana.com":  [None, None, 5, 5, 4, None, None],
+        "monday.com": [None]*7,
+        "trello.com": [None]*7,
+        "wikipedia.org": [3, 3, 3, 3, 3, 3, 3],
+    },
+}
+
+
+def slug(s):
+    return re.sub(r'[^a-z0-9]+', '-', s.lower()).strip('-')
+
+
+def url_for(domain, keyword):
+    return f"https://www.{domain}/{slug(keyword)}"
+
+
+def main():
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        raise SystemExit("DATABASE_URL no está configurada")
+    host = urlparse(url).hostname or ""
+    print(f"DB HOST: {host}")
+    if "switchyard" in host and os.getenv("FORCE_PROD") != "1":
+        raise SystemExit("ABORT: parece PRODUCCIÓN (switchyard). No se siembra.")
+
+    conn = psycopg2.connect(url)
+    conn.autocommit = False
+    cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+    # 1) Proyecto (idempotente: si existe, limpiamos sus datos y reutilizamos id)
+    cur.execute(
+        "SELECT id FROM manual_ai_projects WHERE user_id = %s AND name = %s",
+        (OWNER_USER_ID, PROJECT_NAME),
+    )
+    row = cur.fetchone()
+    if row:
+        project_id = row["id"]
+        print(f"Proyecto demo existente id={project_id} → limpiando datos previos")
+        cur.execute("DELETE FROM manual_ai_global_domains WHERE project_id = %s", (project_id,))
+        cur.execute("DELETE FROM manual_ai_results WHERE project_id = %s", (project_id,))
+        cur.execute("DELETE FROM manual_ai_snapshots WHERE project_id = %s", (project_id,))
+        cur.execute("DELETE FROM manual_ai_keywords WHERE project_id = %s", (project_id,))
+        cur.execute(
+            """UPDATE manual_ai_projects
+               SET domain=%s, country_code=%s, is_active=TRUE, selected_competitors=%s,
+                   description=%s, updated_at=NOW()
+               WHERE id=%s""",
+            (PROJECT_DOMAIN, COUNTRY, json.dumps(COMPETITORS),
+             "Proyecto de demostración para el modal de comparación histórica.", project_id),
+        )
+    else:
+        cur.execute(
+            """INSERT INTO manual_ai_projects
+                 (user_id, name, description, domain, country_code, is_active, selected_competitors)
+               VALUES (%s, %s, %s, %s, %s, TRUE, %s)
+               RETURNING id""",
+            (OWNER_USER_ID, PROJECT_NAME,
+             "Proyecto de demostración para el modal de comparación histórica.",
+             PROJECT_DOMAIN, COUNTRY, json.dumps(COMPETITORS)),
+        )
+        project_id = cur.fetchone()["id"]
+        print(f"Proyecto demo creado id={project_id}")
+
+    # 2) Keywords
+    keyword_ids = {}
+    for kw in KEYWORDS:
+        cur.execute(
+            """INSERT INTO manual_ai_keywords (project_id, keyword, is_active)
+               VALUES (%s, %s, TRUE) RETURNING id""",
+            (project_id, kw),
+        )
+        keyword_ids[kw] = cur.fetchone()["id"]
+    print(f"Keywords insertadas: {len(keyword_ids)}")
+
+    # 3) Resultados + dominios globales por (keyword, fecha)
+    n_results = 0
+    n_domains = 0
+    for kw, profiles in KEYWORDS.items():
+        kid = keyword_ids[kw]
+        for i, d in enumerate(DATES):
+            # Construir lista de (domain, position) presentes ese día
+            present = []
+            for domain, positions in profiles.items():
+                pos = positions[i]
+                if pos is not None:
+                    present.append((domain, pos))
+            present.sort(key=lambda x: x[1])  # por posición
+
+            references = [{
+                "link": url_for(domain, kw),
+                "index": pos - 1,
+                "title": f"{kw.title()} | {domain}",
+                "source": domain,
+            } for domain, pos in present]
+
+            proj_pos = next((pos for domain, pos in present if domain == PROJECT_DOMAIN), None)
+            domain_mentioned = proj_pos is not None
+
+            ai_analysis_data = {
+                "has_ai_overview": True,
+                "domain_is_ai_source": domain_mentioned,
+                "domain_ai_source_position": proj_pos,
+                "debug_info": {"references_found": references},
+            }
+
+            cur.execute(
+                """INSERT INTO manual_ai_results
+                     (project_id, keyword_id, analysis_date, keyword, domain,
+                      has_ai_overview, domain_mentioned, domain_position,
+                      ai_elements_count, impact_score, raw_serp_data, ai_analysis_data, country_code)
+                   VALUES (%s,%s,%s,%s,%s, TRUE,%s,%s, %s,%s,%s,%s,%s)""",
+                (project_id, kid, d, kw, PROJECT_DOMAIN,
+                 domain_mentioned, proj_pos,
+                 len(references), (proj_pos and (10 - proj_pos) * 10) or 0,
+                 json.dumps({}), json.dumps(ai_analysis_data), COUNTRY),
+            )
+            n_results += 1
+
+            for domain, pos in present:
+                cur.execute(
+                    """INSERT INTO manual_ai_global_domains
+                         (project_id, keyword_id, analysis_date, keyword, project_domain,
+                          detected_domain, domain_position, domain_title, domain_source_url,
+                          country_code, is_project_domain, is_selected_competitor)
+                       VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+                    (project_id, kid, d, kw, PROJECT_DOMAIN,
+                     domain, pos, f"{kw.title()} | {domain}", url_for(domain, kw),
+                     COUNTRY, domain == PROJECT_DOMAIN, domain in COMPETITORS),
+                )
+                n_domains += 1
+
+    # 4) Snapshots por fecha (para coherencia del histórico de visibilidad)
+    for d in DATES:
+        cur.execute(
+            """SELECT
+                  COUNT(*) AS total,
+                  COUNT(*) FILTER (WHERE has_ai_overview) AS with_ai,
+                  COUNT(*) FILTER (WHERE domain_mentioned) AS mentions,
+                  AVG(domain_position) FILTER (WHERE domain_mentioned) AS avg_pos
+               FROM manual_ai_results WHERE project_id=%s AND analysis_date=%s""",
+            (project_id, d),
+        )
+        agg = cur.fetchone()
+        with_ai = agg["with_ai"] or 0
+        mentions = agg["mentions"] or 0
+        vis = (mentions / with_ai * 100) if with_ai else 0
+        cur.execute(
+            """INSERT INTO manual_ai_snapshots
+                 (project_id, snapshot_date, total_keywords, active_keywords,
+                  keywords_with_ai, domain_mentions, avg_position, visibility_percentage,
+                  change_type)
+               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,'daily_analysis')
+               ON CONFLICT (project_id, snapshot_date) DO UPDATE SET
+                  keywords_with_ai=EXCLUDED.keywords_with_ai,
+                  domain_mentions=EXCLUDED.domain_mentions,
+                  avg_position=EXCLUDED.avg_position,
+                  visibility_percentage=EXCLUDED.visibility_percentage""",
+            (project_id, d, len(KEYWORDS), len(KEYWORDS), with_ai, mentions,
+             agg["avg_pos"], round(vis, 2)),
+        )
+
+    conn.commit()
+    print(f"OK · results={n_results} global_domains={n_domains} dates={len(DATES)}")
+    print(f"Fechas: {DATES[0]} .. {DATES[-1]}")
+    print(f"Proyecto demo id={project_id} owner={OWNER_USER_ID} ({PROJECT_DOMAIN})")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/search_console_webapp/static/js/manual-ai-system-modular.js
+++ b/search_console_webapp/static/js/manual-ai-system-modular.js
@@ -121,7 +121,20 @@ import {
     // ✨ NEW (2026-04-09): AIO vs Organic comparison
     loadAioVsOrganicComparison,
     renderAioVsOrganicComparison,
-    showNoAioVsOrganicMessage
+    showNoAioVsOrganicMessage,
+    // ✨ NEW (2026-06-21): Historical comparison (See historic)
+    openHistoricalComparison,
+    loadHistoricalComparison,
+    hideHistoricalComparison,
+    renderHistoricalComparison,
+    switchHistoricalTab,
+    renderHistoricalPanel,
+    renderHistoricalList,
+    renderHistoricalRow,
+    renderHistoricalDelta,
+    renderHistoricalUrl,
+    formatHistPosition,
+    formatHistDate
 } from './manual-ai/manual-ai-analytics.js';
 
 // Exports
@@ -276,6 +289,20 @@ Object.assign(ManualAISystem.prototype, {
     loadAioVsOrganicComparison,
     renderAioVsOrganicComparison,
     showNoAioVsOrganicMessage,
+
+    // ✨ NEW (2026-06-21): Historical comparison (See historic)
+    openHistoricalComparison,
+    loadHistoricalComparison,
+    hideHistoricalComparison,
+    renderHistoricalComparison,
+    switchHistoricalTab,
+    renderHistoricalPanel,
+    renderHistoricalList,
+    renderHistoricalRow,
+    renderHistoricalDelta,
+    renderHistoricalUrl,
+    formatHistPosition,
+    formatHistDate,
 
     // Exports
     handleDownloadExcel,

--- a/search_console_webapp/static/js/manual-ai/manual-ai-analytics-historical.js
+++ b/search_console_webapp/static/js/manual-ai/manual-ai-analytics-historical.js
@@ -1,0 +1,304 @@
+/**
+ * Manual AI System - Analytics — Comparación histórica de AI Overview
+ *
+ * Modal "See historic" de la tabla AI Overview Keywords Details. Compara la
+ * presencia en AI Overview entre el primer y el último análisis disponibles
+ * dentro del rango seleccionado (7 / 30 / 90 días) para el dominio del proyecto
+ * y cada competidor: keywords ganadas, perdidas y mantenidas, con sus URLs.
+ *
+ * Datos: GET /manual-ai/api/projects/{id}/ai-overview-historical?days={days}
+ */
+
+// ================================
+// APERTURA / CARGA
+// ================================
+
+export function openHistoricalComparison() {
+    const projectId = this.currentAnalyticsData?.projectId
+        || parseInt(this.elements.analyticsProjectSelect?.value)
+        || this.currentProject?.id;
+
+    if (!projectId) {
+        this.showError?.('Select a project first');
+        return;
+    }
+
+    const days = this.elements.analyticsTimeRange?.value || 30;
+
+    const modal = document.getElementById('historicalComparisonModal');
+    const body = document.getElementById('historicalComparisonBody');
+    if (!modal || !body) return;
+
+    // Estado de carga + abrir modal
+    body.innerHTML = `
+        <div class="hist-loading">
+            <i class="fas fa-spinner fa-spin"></i>
+            <p>Loading historical comparison...</p>
+        </div>
+    `;
+    modal.classList.add('show');
+
+    this.loadHistoricalComparison(projectId, days);
+}
+
+export async function loadHistoricalComparison(projectId, days) {
+    const body = document.getElementById('historicalComparisonBody');
+    if (!body) return;
+
+    try {
+        const token = Date.now();
+        this._historicalToken = token;
+
+        const response = await fetch(`/manual-ai/api/projects/${projectId}/ai-overview-historical?days=${days}`);
+        if (!response.ok) throw new Error('Failed to load historical comparison');
+
+        const result = await response.json();
+        if (this._historicalToken !== token) return; // evitar pisado por race
+
+        const data = (result && result.data) || {};
+        this.renderHistoricalComparison(data);
+    } catch (error) {
+        console.error('Error loading historical comparison:', error);
+        body.innerHTML = `
+            <div class="hist-empty">
+                <i class="fas fa-exclamation-triangle"></i>
+                <p>Failed to load historical comparison</p>
+            </div>
+        `;
+    }
+}
+
+export function hideHistoricalComparison() {
+    const modal = document.getElementById('historicalComparisonModal');
+    if (modal) modal.classList.remove('show');
+    this._historicalData = null;
+}
+
+// ================================
+// RENDER
+// ================================
+
+export function renderHistoricalComparison(data) {
+    const body = document.getElementById('historicalComparisonBody');
+    if (!body) return;
+
+    if (!data || data.comparison_available !== true) {
+        const count = data?.date_count || 0;
+        body.innerHTML = `
+            <div class="hist-empty">
+                <i class="fas fa-clock-rotate-left"></i>
+                <p>Not enough history to compare yet</p>
+                <small>
+                    ${count <= 1
+                        ? 'Only one analysis is available in this range. A historical comparison needs at least two analyses on different dates.'
+                        : 'No comparable analyses were found in the selected range.'}
+                    Try a wider time range or run another analysis.
+                </small>
+            </div>
+        `;
+        return;
+    }
+
+    const entities = Array.isArray(data.entities) ? data.entities : [];
+    this._historicalData = data;
+    this._historicalActiveTab = 0;
+
+    const prev = this.formatHistDate(data.compared_dates?.previous);
+    const curr = this.formatHistDate(data.compared_dates?.current);
+
+    const tabsHtml = entities.map((e, i) => `
+        <button type="button"
+                class="hist-tab ${i === 0 ? 'active' : ''}"
+                data-hist-tab="${i}"
+                onclick="manualAI.switchHistoricalTab(${i})">
+            ${e.type === 'project' ? '<i class="fas fa-star"></i> ' : ''}${this.escapeHtml(e.label || e.domain || '')}
+        </button>
+    `).join('');
+
+    body.innerHTML = `
+        <div class="hist-meta">
+            <i class="fas fa-calendar-alt"></i>
+            Comparing <strong>${prev}</strong>
+            <i class="fas fa-arrow-right hist-meta-arrow"></i>
+            <strong>${curr}</strong>
+            <span class="hist-meta-sep">·</span>
+            Last ${Number(data.days) || ''} days
+            <span class="hist-meta-sep">·</span>
+            ${Number(data.date_count) || 0} analyses in range
+        </div>
+        <div class="hist-tabs" role="tablist">${tabsHtml}</div>
+        <div class="hist-panel" id="historicalPanel"></div>
+    `;
+
+    this.renderHistoricalPanel(0);
+}
+
+export function switchHistoricalTab(index) {
+    this._historicalActiveTab = index;
+    document.querySelectorAll('#historicalComparisonModal .hist-tab').forEach(tab => {
+        tab.classList.toggle('active', String(tab.dataset.histTab) === String(index));
+    });
+    this.renderHistoricalPanel(index);
+}
+
+export function renderHistoricalPanel(index) {
+    const panel = document.getElementById('historicalPanel');
+    const data = this._historicalData;
+    if (!panel || !data) return;
+
+    const entity = (data.entities || [])[index];
+    if (!entity) {
+        panel.innerHTML = '';
+        return;
+    }
+
+    const s = entity.summary || {};
+    const net = (s.current_count || 0) - (s.previous_count || 0);
+    const netClass = net > 0 ? 'hist-net--up' : (net < 0 ? 'hist-net--down' : '');
+    const netLabel = net > 0 ? `+${net}` : String(net);
+
+    panel.innerHTML = `
+        <div class="hist-scorecards">
+            <div class="hist-card">
+                <span class="hist-card-value">${s.previous_count || 0}</span>
+                <span class="hist-card-label">Mentioned then</span>
+            </div>
+            <div class="hist-card">
+                <span class="hist-card-value">${s.current_count || 0}</span>
+                <span class="hist-card-label">Mentioned now</span>
+                <span class="hist-net ${netClass}">${netLabel}</span>
+            </div>
+            <div class="hist-card hist-card--gain">
+                <span class="hist-card-value">+${s.gained_count || 0}</span>
+                <span class="hist-card-label">Gained</span>
+            </div>
+            <div class="hist-card hist-card--loss">
+                <span class="hist-card-value">−${s.lost_count || 0}</span>
+                <span class="hist-card-label">Lost</span>
+            </div>
+            <div class="hist-card">
+                <span class="hist-card-value">${s.maintained_count || 0}</span>
+                <span class="hist-card-label">Maintained</span>
+            </div>
+        </div>
+
+        <div class="hist-lists">
+            ${this.renderHistoricalList('lost', entity.lost || [])}
+            ${this.renderHistoricalList('gained', entity.gained || [])}
+            ${this.renderHistoricalList('maintained', entity.maintained || [])}
+        </div>
+    `;
+}
+
+export function renderHistoricalList(kind, items) {
+    const meta = {
+        lost: { title: 'Lost', icon: 'fa-circle-minus', cls: 'lost',
+                hint: 'Mentioned before, not anymore' },
+        gained: { title: 'Gained', icon: 'fa-circle-plus', cls: 'gain',
+                  hint: 'Newly mentioned' },
+        maintained: { title: 'Maintained', icon: 'fa-equals', cls: 'kept',
+                      hint: 'Mentioned on both dates' },
+    }[kind];
+
+    const rowsHtml = items.length
+        ? items.map(it => this.renderHistoricalRow(kind, it)).join('')
+        : `<div class="hist-row hist-row--empty">No keywords</div>`;
+
+    // Maintained puede ser largo: colapsable para no saturar.
+    const open = kind !== 'maintained' ? 'open' : '';
+
+    return `
+        <details class="hist-list hist-list--${meta.cls}" ${open}>
+            <summary class="hist-list-summary">
+                <span class="hist-list-title">
+                    <i class="fas ${meta.icon}"></i> ${meta.title}
+                    <span class="hist-list-count">${items.length}</span>
+                </span>
+                <span class="hist-list-hint">${meta.hint}</span>
+            </summary>
+            <div class="hist-rows">${rowsHtml}</div>
+        </details>
+    `;
+}
+
+export function renderHistoricalRow(kind, item) {
+    const keyword = this.escapeHtml(item.keyword || '');
+
+    let positionHtml = '';
+    if (kind === 'lost') {
+        positionHtml = `<span class="hist-pos">${this.formatHistPosition(item.previous_position)}</span>`;
+    } else if (kind === 'gained') {
+        positionHtml = `<span class="hist-pos">${this.formatHistPosition(item.position)}</span>`;
+    } else {
+        positionHtml = this.renderHistoricalDelta(item);
+    }
+
+    const url = kind === 'lost' ? item.previous_url : item.url;
+    const urlHtml = this.renderHistoricalUrl(url);
+
+    return `
+        <div class="hist-row">
+            <span class="hist-row-kw" title="${keyword}">${keyword}</span>
+            ${positionHtml}
+            ${urlHtml}
+        </div>
+    `;
+}
+
+export function renderHistoricalDelta(item) {
+    const pp = item.previous_position;
+    const cp = item.current_position;
+    const delta = item.position_delta;
+
+    let arrow = '<i class="fas fa-minus hist-delta-flat"></i>';
+    if (typeof delta === 'number' && delta < 0) {
+        arrow = `<i class="fas fa-arrow-up hist-delta-up"></i><span class="hist-delta-up">${Math.abs(delta)}</span>`;
+    } else if (typeof delta === 'number' && delta > 0) {
+        arrow = `<i class="fas fa-arrow-down hist-delta-down"></i><span class="hist-delta-down">${delta}</span>`;
+    }
+
+    return `
+        <span class="hist-pos hist-pos--delta" title="Position ${this.formatHistPosition(pp)} → ${this.formatHistPosition(cp)}">
+            ${this.formatHistPosition(pp)} <i class="fas fa-arrow-right hist-pos-sep"></i> ${this.formatHistPosition(cp)}
+            ${arrow}
+        </span>
+    `;
+}
+
+export function renderHistoricalUrl(url) {
+    if (!url) {
+        return `<span class="hist-url hist-url--none">—</span>`;
+    }
+    const safe = this.escapeHtml(url);
+    let display = url;
+    try {
+        const u = new URL(url);
+        display = u.hostname.replace(/^www\./, '') + (u.pathname && u.pathname !== '/' ? u.pathname : '');
+    } catch (_) { /* deja la url tal cual */ }
+    if (display.length > 48) display = display.slice(0, 45) + '…';
+
+    return `
+        <a class="hist-url" href="${safe}" target="_blank" rel="noopener noreferrer" title="${safe}">
+            <i class="fas fa-link"></i> ${this.escapeHtml(display)}
+        </a>
+    `;
+}
+
+// ================================
+// HELPERS
+// ================================
+
+export function formatHistPosition(pos) {
+    if (pos === null || pos === undefined) return '—';
+    return `#${pos}`;
+}
+
+export function formatHistDate(value) {
+    if (!value) return '—';
+    try {
+        const d = new Date(value + 'T00:00:00');
+        return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+    } catch (_) {
+        return value;
+    }
+}

--- a/search_console_webapp/static/js/manual-ai/manual-ai-analytics.js
+++ b/search_console_webapp/static/js/manual-ai/manual-ai-analytics.js
@@ -11,3 +11,4 @@ export * from './manual-ai-analytics-urls.js';
 export * from './manual-ai-analytics-table.js';
 export * from './manual-ai-analytics-comparative.js';
 export * from './manual-ai-analytics-aio-organic.js';
+export * from './manual-ai-analytics-historical.js';

--- a/search_console_webapp/static/manual-ai-historical.css
+++ b/search_console_webapp/static/manual-ai-historical.css
@@ -1,37 +1,84 @@
 /* =================================================================
    Manual AI — Comparación histórica de AI Overview ("See historic")
-   Estilos del botón de la cabecera de la tabla y del modal de
-   comparación (scorecards + listas gained/lost/maintained).
-   Aislado del resto: usa las variables --manual-ai-* ya existentes.
+   ESTILO SEGÚN BRANDBOOK CLICANDSEO v1.1.
+   - Solo colores de la paleta oficial (sin azules/ámbar inventados).
+   - Tipografía Inter Tight. Sin gradientes. Formas "ultra soft".
+   - Bio-Lime (#d9f9b8) solo como barra de subrayado de acento, nunca
+     como fondo de elementos ni como texto sobre blanco.
+   - Sin pills/badges informativos: los contadores son texto plano.
+   Tokens de marca scopeados al modal + botón (no afectan al resto).
    ================================================================= */
 
-/* --- Cabecera de sección con acción a la derecha --- */
-.section-header.section-header--with-action {
-  align-items: flex-start;
-  gap: var(--manual-ai-spacing-md);
-}
-
-.section-header--with-action .section-header-main {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-}
-
+#historicalComparisonModal,
 .historical-btn {
+  --hist-text: #0F172A;            /* text-primary   */
+  --hist-text-secondary: #64748B;  /* text-secondary */
+  --hist-text-tertiary: #94A3B8;   /* text-tertiary  */
+  --hist-bg: #FFFFFF;              /* bg-paper       */
+  --hist-bg-subtle: #F1F5F9;       /* bg-subtle      */
+  --hist-border: #E2E8F0;          /* border         */
+  --hist-border-subtle: #EEF2F7;   /* border-subtle  */
+  --hist-accent: #d9f9b8;          /* Bio-Lime       */
+  --hist-success: #3CB371;
+  --hist-error: #E05252;
+  --hist-radius-sm: 8px;
+  --hist-radius-md: 20px;
+  --hist-shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04), 0 2px 8px rgba(15, 23, 42, 0.06);
+  --hist-shadow-md: 0 2px 4px rgba(15, 23, 42, 0.04), 0 8px 24px rgba(15, 23, 42, 0.08);
+  --hist-font: 'Inter Tight', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --hist-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --hist-transition: 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+/* --- Botón disparador "See historic" (brand: secondary, pill) --- */
+.historical-btn.historical-btn {
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  gap: var(--manual-ai-spacing-sm);
+  gap: 0.5rem;
   white-space: nowrap;
+  font-family: var(--hist-font);
+  font-weight: 600;
+  font-size: 0.875rem;
+  padding: 10px 22px;
+  border-radius: 9999px;            /* pill: permitido SOLO en botones */
+  border: 1.5px solid var(--hist-border);
+  background: transparent;
+  color: var(--hist-text);
+  transition: var(--hist-transition);
 }
 
-/* --- Modal --- */
+.historical-btn.historical-btn:hover {
+  transform: translateY(-2px);
+  background: var(--hist-bg-subtle);
+  box-shadow: var(--hist-shadow-sm);
+}
+
+.historical-btn.historical-btn i {
+  color: var(--hist-text-tertiary);
+}
+
+/* --- Modal: forma "ultra soft" (radius-md) y tipografía de marca --- */
 .modal-content.modal-historical {
   max-width: 920px;
+  border-radius: var(--hist-radius-md);
+  font-family: var(--hist-font);
+}
+
+#historicalComparisonModal .modal-header h3 {
+  font-family: var(--hist-font);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--hist-text);
+}
+
+#historicalComparisonModal .modal-header h3 i {
+  color: var(--hist-text-tertiary);
 }
 
 #historicalComparisonModal .modal-body {
-  padding: var(--manual-ai-spacing-lg);
+  padding: var(--hist-radius-md);
+  color: var(--hist-text);
 }
 
 /* --- Estados de carga / vacío --- */
@@ -42,27 +89,27 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  gap: var(--manual-ai-spacing-sm);
-  padding: var(--manual-ai-spacing-2xl) var(--manual-ai-spacing-lg);
-  color: var(--manual-ai-gray-500);
+  gap: 0.5rem;
+  padding: 3rem 1.5rem;
+  color: var(--hist-text-secondary);
 }
 
 .hist-loading i,
 .hist-empty i {
   font-size: 2rem;
-  color: var(--manual-ai-gray-400);
+  color: var(--hist-text-tertiary);
 }
 
 .hist-empty p {
   margin: 0;
-  font-weight: 600;
-  color: var(--manual-ai-gray-700);
+  font-weight: 700;
+  color: var(--hist-text);
 }
 
 .hist-empty small {
   max-width: 460px;
-  color: var(--manual-ai-gray-500);
-  line-height: 1.45;
+  color: var(--hist-text-secondary);
+  line-height: 1.6;
 }
 
 /* --- Meta (fechas comparadas) --- */
@@ -70,22 +117,23 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--manual-ai-spacing-xs);
+  gap: 0.3rem;
   font-size: 0.9rem;
-  color: var(--manual-ai-gray-600);
-  background: var(--manual-ai-gray-50);
-  border: var(--manual-ai-border-width) solid var(--manual-ai-gray-200);
-  border-radius: var(--manual-ai-border-radius);
-  padding: var(--manual-ai-spacing-sm) var(--manual-ai-spacing-md);
-  margin-bottom: var(--manual-ai-spacing-lg);
+  color: var(--hist-text-secondary);
+  background: var(--hist-bg-subtle);
+  border: 1px solid var(--hist-border-subtle);
+  border-radius: var(--hist-radius-sm);
+  padding: 0.6rem 1rem;
+  margin-bottom: 1.75rem;
 }
 
 .hist-meta strong {
-  color: var(--manual-ai-gray-900);
+  color: var(--hist-text);
+  font-weight: 700;
 }
 
 .hist-meta i {
-  color: var(--manual-ai-accent);
+  color: var(--hist-text-tertiary);
 }
 
 .hist-meta-arrow {
@@ -93,54 +141,65 @@
 }
 
 .hist-meta-sep {
-  color: var(--manual-ai-gray-300);
-  margin: 0 0.15rem;
+  color: var(--hist-text-tertiary);
+  margin: 0 0.2rem;
 }
 
-/* --- Tabs (tu dominio + competidores) --- */
+/* --- Tabs (tu dominio + competidores) — acento Bio-Lime en activo --- */
 .hist-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--manual-ai-spacing-xs);
-  border-bottom: 2px solid var(--manual-ai-gray-100);
-  margin-bottom: var(--manual-ai-spacing-lg);
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--hist-border);
+  margin-bottom: 1.75rem;
 }
 
 .hist-tab {
+  position: relative;
   border: none;
   background: none;
   cursor: pointer;
-  padding: var(--manual-ai-spacing-sm) var(--manual-ai-spacing-md);
+  font-family: var(--hist-font);
+  padding: 0.6rem 1rem;
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--manual-ai-gray-500);
-  border-bottom: 2px solid transparent;
-  margin-bottom: -2px;
-  transition: var(--manual-ai-transition);
-  border-radius: var(--manual-ai-border-radius) var(--manual-ai-border-radius) 0 0;
+  color: var(--hist-text-secondary);
+  margin-bottom: -1px;
+  transition: color var(--hist-transition);
 }
 
 .hist-tab:hover {
-  color: var(--manual-ai-gray-800);
-  background: var(--manual-ai-gray-50);
+  color: var(--hist-text);
 }
 
 .hist-tab.active {
-  color: var(--manual-ai-accent);
-  border-bottom-color: var(--manual-ai-accent);
+  color: var(--hist-text);
+  font-weight: 700;
+}
+
+/* Subrayado de marca (Bio-Lime) bajo la pestaña activa */
+.hist-tab.active::after {
+  content: '';
+  position: absolute;
+  left: 0.6rem;
+  right: 0.6rem;
+  bottom: 0;
+  height: 3px;
+  background: var(--hist-accent);
+  border-radius: 2px;
 }
 
 .hist-tab i {
-  color: var(--manual-ai-warning);
-  margin-right: 0.25rem;
+  color: var(--hist-text-tertiary);
+  margin-right: 0.3rem;
 }
 
-/* --- Scorecards --- */
+/* --- Scorecards (tarjetas de marca: radius suave, hover con borde Bio-Lime) --- */
 .hist-scorecards {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
-  gap: var(--manual-ai-spacing-md);
-  margin-bottom: var(--manual-ai-spacing-xl);
+  gap: 1rem;
+  margin-bottom: 2rem;
 }
 
 .hist-card {
@@ -150,53 +209,56 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  gap: 0.15rem;
-  padding: var(--manual-ai-spacing-md);
-  background: white;
-  border: var(--manual-ai-border-width) solid var(--manual-ai-gray-200);
-  border-radius: var(--manual-ai-border-radius);
-  box-shadow: var(--manual-ai-shadow-sm);
+  gap: 0.2rem;
+  padding: 1rem;
+  background: var(--hist-bg);
+  border: 1px solid var(--hist-border-subtle);
+  border-radius: var(--hist-radius-sm);
+  box-shadow: var(--hist-shadow-sm);
+  transition: border-color var(--hist-transition);
 }
 
 .hist-card-value {
   font-size: 1.6rem;
-  font-weight: 700;
-  color: var(--manual-ai-gray-900);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--hist-text);
   line-height: 1.1;
 }
 
 .hist-card-label {
-  font-size: 0.72rem;
+  font-size: 0.7rem;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.03em;
-  color: var(--manual-ai-gray-500);
+  letter-spacing: 0.1em;
+  color: var(--hist-text-tertiary);
 }
 
-.hist-card--gain .hist-card-value { color: var(--manual-ai-success); }
-.hist-card--loss .hist-card-value { color: var(--manual-ai-error); }
+.hist-card--gain .hist-card-value { color: var(--hist-success); }
+.hist-card--loss .hist-card-value { color: var(--hist-error); }
 
 .hist-net {
   position: absolute;
-  top: 0.4rem;
-  right: 0.5rem;
+  top: 0.45rem;
+  right: 0.55rem;
   font-size: 0.72rem;
   font-weight: 700;
-  color: var(--manual-ai-gray-400);
+  color: var(--hist-text-tertiary);
 }
 
-.hist-net--up { color: var(--manual-ai-success); }
-.hist-net--down { color: var(--manual-ai-error); }
+.hist-net--up { color: var(--hist-success); }
+.hist-net--down { color: var(--hist-error); }
 
 /* --- Listas (gained / lost / maintained) --- */
 .hist-lists {
   display: flex;
   flex-direction: column;
-  gap: var(--manual-ai-spacing-md);
+  gap: 1rem;
 }
 
 .hist-list {
-  border: var(--manual-ai-border-width) solid var(--manual-ai-gray-200);
-  border-radius: var(--manual-ai-border-radius);
+  border: 1px solid var(--hist-border-subtle);
+  border-radius: var(--hist-radius-sm);
   overflow: hidden;
 }
 
@@ -204,10 +266,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--manual-ai-spacing-md);
-  padding: var(--manual-ai-spacing-sm) var(--manual-ai-spacing-md);
+  gap: 1rem;
+  padding: 0.6rem 1rem;
   cursor: pointer;
-  background: var(--manual-ai-gray-50);
+  background: var(--hist-bg-subtle);
   list-style: none;
   user-select: none;
 }
@@ -215,13 +277,13 @@
 .hist-list-summary::-webkit-details-marker { display: none; }
 
 .hist-list-summary::before {
-  content: '\f078'; /* chevron-down */
+  content: '\f078'; /* chevron-down (Font Awesome) */
   font-family: 'Font Awesome 6 Free';
   font-weight: 900;
   font-size: 0.7rem;
-  color: var(--manual-ai-gray-400);
+  color: var(--hist-text-tertiary);
   margin-right: 0.4rem;
-  transition: transform 0.15s ease;
+  transition: transform 0.3s var(--hist-ease);
 }
 
 .hist-list:not([open]) .hist-list-summary::before {
@@ -235,36 +297,32 @@
   font-weight: 700;
   font-size: 0.9rem;
   flex: 1;
+  color: var(--hist-text);
 }
 
+/* Contador = texto plano (brandbook: sin badges/pills informativos) */
 .hist-list-count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 1.4rem;
-  height: 1.4rem;
-  padding: 0 0.4rem;
-  border-radius: 999px;
-  font-size: 0.72rem;
-  background: var(--manual-ai-gray-200);
-  color: var(--manual-ai-gray-700);
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--hist-text-tertiary);
 }
 
 .hist-list-hint {
   font-size: 0.75rem;
-  color: var(--manual-ai-gray-400);
+  color: var(--hist-text-tertiary);
   font-style: italic;
 }
 
-.hist-list--lost .hist-list-title { color: var(--manual-ai-error); }
-.hist-list--lost .hist-list-title i { color: var(--manual-ai-error); }
-.hist-list--lost .hist-list-count { background: #fde8e8; color: #b91c1c; }
+.hist-list--lost .hist-list-title,
+.hist-list--lost .hist-list-title i,
+.hist-list--lost .hist-list-count { color: var(--hist-error); }
 
-.hist-list--gain .hist-list-title { color: var(--manual-ai-success); }
-.hist-list--gain .hist-list-title i { color: var(--manual-ai-success); }
-.hist-list--gain .hist-list-count { background: #dcfce7; color: #15803d; }
+.hist-list--gain .hist-list-title,
+.hist-list--gain .hist-list-title i,
+.hist-list--gain .hist-list-count { color: var(--hist-success); }
 
-.hist-list--kept .hist-list-title i { color: var(--manual-ai-gray-500); }
+.hist-list--kept .hist-list-title i { color: var(--hist-text-tertiary); }
+.hist-list--kept .hist-list-count { color: var(--hist-text-tertiary); }
 
 .hist-rows {
   display: flex;
@@ -275,9 +333,9 @@
   display: grid;
   grid-template-columns: 1fr auto minmax(0, 16rem);
   align-items: center;
-  gap: var(--manual-ai-spacing-md);
-  padding: var(--manual-ai-spacing-sm) var(--manual-ai-spacing-md);
-  border-top: var(--manual-ai-border-width) solid var(--manual-ai-gray-100);
+  gap: 1rem;
+  padding: 0.6rem 1rem;
+  border-top: 1px solid var(--hist-border-subtle);
   font-size: 0.85rem;
 }
 
@@ -286,14 +344,14 @@
 .hist-row--empty {
   display: block;
   text-align: center;
-  color: var(--manual-ai-gray-400);
+  color: var(--hist-text-tertiary);
   font-style: italic;
-  padding: var(--manual-ai-spacing-md);
+  padding: 1rem;
 }
 
 .hist-row-kw {
   font-weight: 600;
-  color: var(--manual-ai-gray-800);
+  color: var(--hist-text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -301,8 +359,8 @@
 
 .hist-pos {
   font-variant-numeric: tabular-nums;
-  font-weight: 600;
-  color: var(--manual-ai-gray-700);
+  font-weight: 700;
+  color: var(--hist-text);
   white-space: nowrap;
 }
 
@@ -310,36 +368,42 @@
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  color: var(--manual-ai-gray-600);
-  font-weight: 500;
+  color: var(--hist-text-secondary);
+  font-weight: 600;
 }
 
 .hist-pos-sep {
   font-size: 0.65rem;
-  color: var(--manual-ai-gray-400);
+  color: var(--hist-text-tertiary);
 }
 
-.hist-delta-up { color: var(--manual-ai-success); font-weight: 700; }
-.hist-delta-down { color: var(--manual-ai-error); font-weight: 700; }
-.hist-delta-flat { color: var(--manual-ai-gray-400); }
+.hist-delta-up { color: var(--hist-success); font-weight: 700; }
+.hist-delta-down { color: var(--hist-error); font-weight: 700; }
+.hist-delta-flat { color: var(--hist-text-tertiary); }
 
+/* URLs: enlaces de marca (texto neutro, subrayado al hover; sin azul) */
 .hist-url {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  color: var(--manual-ai-accent);
+  color: var(--hist-text-secondary);
   text-decoration: none;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 0.8rem;
+  transition: color var(--hist-transition);
 }
 
-.hist-url:hover { text-decoration: underline; }
-.hist-url i { font-size: 0.7rem; color: var(--manual-ai-gray-400); }
+.hist-url:hover {
+  color: var(--hist-text);
+  text-decoration: underline;
+}
+
+.hist-url i { font-size: 0.7rem; color: var(--hist-text-tertiary); }
 
 .hist-url--none {
-  color: var(--manual-ai-gray-300);
+  color: var(--hist-text-tertiary);
   justify-self: start;
 }
 

--- a/search_console_webapp/static/manual-ai-historical.css
+++ b/search_console_webapp/static/manual-ai-historical.css
@@ -1,0 +1,358 @@
+/* =================================================================
+   Manual AI — Comparación histórica de AI Overview ("See historic")
+   Estilos del botón de la cabecera de la tabla y del modal de
+   comparación (scorecards + listas gained/lost/maintained).
+   Aislado del resto: usa las variables --manual-ai-* ya existentes.
+   ================================================================= */
+
+/* --- Cabecera de sección con acción a la derecha --- */
+.section-header.section-header--with-action {
+  align-items: flex-start;
+  gap: var(--manual-ai-spacing-md);
+}
+
+.section-header--with-action .section-header-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.historical-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--manual-ai-spacing-sm);
+  white-space: nowrap;
+}
+
+/* --- Modal --- */
+.modal-content.modal-historical {
+  max-width: 920px;
+}
+
+#historicalComparisonModal .modal-body {
+  padding: var(--manual-ai-spacing-lg);
+}
+
+/* --- Estados de carga / vacío --- */
+.hist-loading,
+.hist-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: var(--manual-ai-spacing-sm);
+  padding: var(--manual-ai-spacing-2xl) var(--manual-ai-spacing-lg);
+  color: var(--manual-ai-gray-500);
+}
+
+.hist-loading i,
+.hist-empty i {
+  font-size: 2rem;
+  color: var(--manual-ai-gray-400);
+}
+
+.hist-empty p {
+  margin: 0;
+  font-weight: 600;
+  color: var(--manual-ai-gray-700);
+}
+
+.hist-empty small {
+  max-width: 460px;
+  color: var(--manual-ai-gray-500);
+  line-height: 1.45;
+}
+
+/* --- Meta (fechas comparadas) --- */
+.hist-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--manual-ai-spacing-xs);
+  font-size: 0.9rem;
+  color: var(--manual-ai-gray-600);
+  background: var(--manual-ai-gray-50);
+  border: var(--manual-ai-border-width) solid var(--manual-ai-gray-200);
+  border-radius: var(--manual-ai-border-radius);
+  padding: var(--manual-ai-spacing-sm) var(--manual-ai-spacing-md);
+  margin-bottom: var(--manual-ai-spacing-lg);
+}
+
+.hist-meta strong {
+  color: var(--manual-ai-gray-900);
+}
+
+.hist-meta i {
+  color: var(--manual-ai-accent);
+}
+
+.hist-meta-arrow {
+  margin: 0 0.15rem;
+}
+
+.hist-meta-sep {
+  color: var(--manual-ai-gray-300);
+  margin: 0 0.15rem;
+}
+
+/* --- Tabs (tu dominio + competidores) --- */
+.hist-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--manual-ai-spacing-xs);
+  border-bottom: 2px solid var(--manual-ai-gray-100);
+  margin-bottom: var(--manual-ai-spacing-lg);
+}
+
+.hist-tab {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: var(--manual-ai-spacing-sm) var(--manual-ai-spacing-md);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--manual-ai-gray-500);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: var(--manual-ai-transition);
+  border-radius: var(--manual-ai-border-radius) var(--manual-ai-border-radius) 0 0;
+}
+
+.hist-tab:hover {
+  color: var(--manual-ai-gray-800);
+  background: var(--manual-ai-gray-50);
+}
+
+.hist-tab.active {
+  color: var(--manual-ai-accent);
+  border-bottom-color: var(--manual-ai-accent);
+}
+
+.hist-tab i {
+  color: var(--manual-ai-warning);
+  margin-right: 0.25rem;
+}
+
+/* --- Scorecards --- */
+.hist-scorecards {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: var(--manual-ai-spacing-md);
+  margin-bottom: var(--manual-ai-spacing-xl);
+}
+
+.hist-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 0.15rem;
+  padding: var(--manual-ai-spacing-md);
+  background: white;
+  border: var(--manual-ai-border-width) solid var(--manual-ai-gray-200);
+  border-radius: var(--manual-ai-border-radius);
+  box-shadow: var(--manual-ai-shadow-sm);
+}
+
+.hist-card-value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--manual-ai-gray-900);
+  line-height: 1.1;
+}
+
+.hist-card-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--manual-ai-gray-500);
+}
+
+.hist-card--gain .hist-card-value { color: var(--manual-ai-success); }
+.hist-card--loss .hist-card-value { color: var(--manual-ai-error); }
+
+.hist-net {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.5rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--manual-ai-gray-400);
+}
+
+.hist-net--up { color: var(--manual-ai-success); }
+.hist-net--down { color: var(--manual-ai-error); }
+
+/* --- Listas (gained / lost / maintained) --- */
+.hist-lists {
+  display: flex;
+  flex-direction: column;
+  gap: var(--manual-ai-spacing-md);
+}
+
+.hist-list {
+  border: var(--manual-ai-border-width) solid var(--manual-ai-gray-200);
+  border-radius: var(--manual-ai-border-radius);
+  overflow: hidden;
+}
+
+.hist-list-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--manual-ai-spacing-md);
+  padding: var(--manual-ai-spacing-sm) var(--manual-ai-spacing-md);
+  cursor: pointer;
+  background: var(--manual-ai-gray-50);
+  list-style: none;
+  user-select: none;
+}
+
+.hist-list-summary::-webkit-details-marker { display: none; }
+
+.hist-list-summary::before {
+  content: '\f078'; /* chevron-down */
+  font-family: 'Font Awesome 6 Free';
+  font-weight: 900;
+  font-size: 0.7rem;
+  color: var(--manual-ai-gray-400);
+  margin-right: 0.4rem;
+  transition: transform 0.15s ease;
+}
+
+.hist-list:not([open]) .hist-list-summary::before {
+  transform: rotate(-90deg);
+}
+
+.hist-list-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 700;
+  font-size: 0.9rem;
+  flex: 1;
+}
+
+.hist-list-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.4rem;
+  height: 1.4rem;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  background: var(--manual-ai-gray-200);
+  color: var(--manual-ai-gray-700);
+}
+
+.hist-list-hint {
+  font-size: 0.75rem;
+  color: var(--manual-ai-gray-400);
+  font-style: italic;
+}
+
+.hist-list--lost .hist-list-title { color: var(--manual-ai-error); }
+.hist-list--lost .hist-list-title i { color: var(--manual-ai-error); }
+.hist-list--lost .hist-list-count { background: #fde8e8; color: #b91c1c; }
+
+.hist-list--gain .hist-list-title { color: var(--manual-ai-success); }
+.hist-list--gain .hist-list-title i { color: var(--manual-ai-success); }
+.hist-list--gain .hist-list-count { background: #dcfce7; color: #15803d; }
+
+.hist-list--kept .hist-list-title i { color: var(--manual-ai-gray-500); }
+
+.hist-rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.hist-row {
+  display: grid;
+  grid-template-columns: 1fr auto minmax(0, 16rem);
+  align-items: center;
+  gap: var(--manual-ai-spacing-md);
+  padding: var(--manual-ai-spacing-sm) var(--manual-ai-spacing-md);
+  border-top: var(--manual-ai-border-width) solid var(--manual-ai-gray-100);
+  font-size: 0.85rem;
+}
+
+.hist-row:first-child { border-top: none; }
+
+.hist-row--empty {
+  display: block;
+  text-align: center;
+  color: var(--manual-ai-gray-400);
+  font-style: italic;
+  padding: var(--manual-ai-spacing-md);
+}
+
+.hist-row-kw {
+  font-weight: 600;
+  color: var(--manual-ai-gray-800);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hist-pos {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--manual-ai-gray-700);
+  white-space: nowrap;
+}
+
+.hist-pos--delta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--manual-ai-gray-600);
+  font-weight: 500;
+}
+
+.hist-pos-sep {
+  font-size: 0.65rem;
+  color: var(--manual-ai-gray-400);
+}
+
+.hist-delta-up { color: var(--manual-ai-success); font-weight: 700; }
+.hist-delta-down { color: var(--manual-ai-error); font-weight: 700; }
+.hist-delta-flat { color: var(--manual-ai-gray-400); }
+
+.hist-url {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--manual-ai-accent);
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8rem;
+}
+
+.hist-url:hover { text-decoration: underline; }
+.hist-url i { font-size: 0.7rem; color: var(--manual-ai-gray-400); }
+
+.hist-url--none {
+  color: var(--manual-ai-gray-300);
+  justify-self: start;
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+  .hist-scorecards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .hist-row {
+    grid-template-columns: 1fr auto;
+    row-gap: 0.35rem;
+  }
+  .hist-url {
+    grid-column: 1 / -1;
+  }
+}

--- a/search_console_webapp/templates/manual_ai_dashboard.html
+++ b/search_console_webapp/templates/manual_ai_dashboard.html
@@ -27,7 +27,10 @@
     
     <!-- CSS específico para Manual AI -->
     <link href="{{ url_for('static', filename='manual-ai.css') }}" rel="stylesheet">
-    
+
+    <!-- ✨ NUEVO (2026-06-21): Comparación histórica AI Overview (See historic) -->
+    <link href="{{ url_for('static', filename='manual-ai-historical.css') }}" rel="stylesheet">
+
     <!-- ✅ FASE 4: Quota UI para Manual AI -->
     <link href="{{ url_for('static', filename='quota-ui.css') }}" rel="stylesheet">
     
@@ -732,23 +735,29 @@
 
                     <!-- AI Overview Keywords Details Section -->
                     <div class="ai-overview-keywords-section">
-                        <div class="section-header">
-                            <h3>
-                                <i class="fas fa-table"></i>
-                                AI Overview Keywords Details
-                                <span class="cg-info-tooltip">
-                                    <i class="fas fa-info-circle"></i>
-                                    <span class="cg-info-tooltip-content">
-                                        <strong>What is this?</strong>
-                                        A detailed table showing every keyword that triggers an AI Overview, with your domain's presence and your competitors' appearances side by side.
-                                        <strong>How to use it</strong>
-                                        Sort or filter the table to find keywords where you are present, absent or losing to competitors — and prioritize your content actions accordingly.
+                        <div class="section-header section-header--with-action">
+                            <div class="section-header-main">
+                                <h3>
+                                    <i class="fas fa-table"></i>
+                                    AI Overview Keywords Details
+                                    <span class="cg-info-tooltip">
+                                        <i class="fas fa-info-circle"></i>
+                                        <span class="cg-info-tooltip-content">
+                                            <strong>What is this?</strong>
+                                            A detailed table showing every keyword that triggers an AI Overview, with your domain's presence and your competitors' appearances side by side.
+                                            <strong>How to use it</strong>
+                                            Sort or filter the table to find keywords where you are present, absent or losing to competitors — and prioritize your content actions accordingly.
+                                        </span>
                                     </span>
-                                </span>
-                            </h3>
-                            <p class="section-description">
-                                Data from the latest analysis showing keywords with AI Overview and domain presence
-                            </p>
+                                </h3>
+                                <p class="section-description">
+                                    Data from the latest analysis showing keywords with AI Overview and domain presence
+                                </p>
+                            </div>
+                            <button type="button" class="btn-secondary historical-btn" onclick="manualAI.openHistoricalComparison()">
+                                <i class="fas fa-clock-rotate-left"></i>
+                                See historic
+                            </button>
                         </div>
                         
                         <div class="ai-overview-keywords-container">
@@ -1792,6 +1801,21 @@ keyword 3"></textarea>
                     <i class="fas fa-save"></i>
                     Save Annotation
                 </button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Historical Comparison Modal (See historic) -->
+    <div class="modal-overlay" id="historicalComparisonModal">
+        <div class="modal-content modal-historical">
+            <div class="modal-header">
+                <h3><i class="fas fa-clock-rotate-left"></i> AI Overview — Historical Comparison</h3>
+                <button type="button" class="modal-close" onclick="manualAI.hideHistoricalComparison()">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+            <div class="modal-body" id="historicalComparisonBody">
+                <!-- Rendered by manual-ai-analytics-historical.js -->
             </div>
         </div>
     </div>

--- a/search_console_webapp/templates/manual_ai_dashboard.html
+++ b/search_console_webapp/templates/manual_ai_dashboard.html
@@ -29,6 +29,10 @@
     <link href="{{ url_for('static', filename='manual-ai.css') }}" rel="stylesheet">
 
     <!-- ✨ NUEVO (2026-06-21): Comparación histórica AI Overview (See historic) -->
+    <!-- Tipografías de marca (brandbook clicandseo) — usadas por el modal histórico -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400;1,700&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link href="{{ url_for('static', filename='manual-ai-historical.css') }}" rel="stylesheet">
 
     <!-- ✅ FASE 4: Quota UI para Manual AI -->

--- a/search_console_webapp/tests/test_manual_ai_historical.py
+++ b/search_console_webapp/tests/test_manual_ai_historical.py
@@ -1,0 +1,213 @@
+"""
+Tests del servicio de comparación histórica de AI Overview (Manual AI).
+
+Cubre la lógica de agregación de
+`StatisticsService.get_ai_overview_historical_comparison` con una BD simulada
+(sin conexión real): clasificación gained / lost / maintained, deltas de
+posición y URLs afectadas, tanto para el dominio del proyecto como para
+competidores. También cubre los casos borde (sin proyecto, una sola fecha).
+
+Ejecutar:  python3 -m pytest tests/test_manual_ai_historical.py -q
+"""
+
+import os
+import importlib
+from datetime import date
+
+os.environ.setdefault("DATABASE_URL", "postgresql://dummy:dummy@localhost:5432/dummy")
+
+import pytest  # noqa: E402
+
+FIRST = date(2026, 5, 22)
+LAST = date(2026, 6, 21)
+
+
+class _Row(dict):
+    """Fila tipo RealDictRow: None para claves ausentes (no KeyError)."""
+    def __getitem__(self, k):
+        return super().get(k)
+
+
+def _r(**kw):
+    return _Row(**kw)
+
+
+class _FakeCursor:
+    """Cursor que decide qué devolver según la SQL ejecutada."""
+
+    def __init__(self, scenario):
+        self.scenario = scenario
+        self._mode = None
+
+    def execute(self, sql, params=None):
+        s = sql or ""
+        if "MIN(analysis_date)" in s:
+            self._mode = "dates"
+        elif "manual_ai_global_domains" in s:
+            self._mode = "global_domains"
+        elif "manual_ai_projects" in s:
+            self._mode = "project"
+        elif "manual_ai_results" in s:
+            self._mode = "results"
+        else:
+            self._mode = None
+
+    def fetchone(self):
+        if self._mode == "project":
+            return self.scenario["project"]
+        if self._mode == "dates":
+            return self.scenario["dates"]
+        return None
+
+    def fetchall(self):
+        if self._mode == "results":
+            return self.scenario["results"]
+        if self._mode == "global_domains":
+            return self.scenario["global_domains"]
+        return []
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def __init__(self, scenario):
+        self.scenario = scenario
+
+    def cursor(self, *a, **k):
+        return _FakeCursor(self.scenario)
+
+    def close(self):
+        pass
+
+
+def _patch_db(monkeypatch, scenario):
+    mod = importlib.import_module("manual_ai.services._statistics.historical")
+    monkeypatch.setattr(mod, "get_db_connection", lambda: _FakeConn(scenario))
+
+
+def _full_scenario():
+    """Escenario rico: ganadas, perdidas y mantenidas para dominio y competidor."""
+    return {
+        "project": _r(domain="example.com", selected_competitors=["comp.com"]),
+        "dates": _r(first_date=FIRST, last_date=LAST, date_count=4),
+        "results": [
+            # first_date — dominio propio menciona kw1 (pos3) y kw2 (pos5)
+            _r(keyword_id=1, keyword="seo tips", analysis_date=FIRST, domain_mentioned=True, domain_position=3),
+            _r(keyword_id=2, keyword="ai search", analysis_date=FIRST, domain_mentioned=True, domain_position=5),
+            _r(keyword_id=3, keyword="serp", analysis_date=FIRST, domain_mentioned=False, domain_position=None),
+            # last_date — kw1 mejora (pos2), kw3 nueva (pos4), kw2 ya no aparece
+            _r(keyword_id=1, keyword="seo tips", analysis_date=LAST, domain_mentioned=True, domain_position=2),
+            _r(keyword_id=3, keyword="serp", analysis_date=LAST, domain_mentioned=True, domain_position=4),
+            _r(keyword_id=2, keyword="ai search", analysis_date=LAST, domain_mentioned=False, domain_position=None),
+        ],
+        "global_domains": [
+            # Dominio propio (is_project_domain=True) con URLs
+            _r(keyword_id=1, analysis_date=FIRST, detected_domain="example.com", domain_position=3,
+               domain_source_url="https://example.com/seo", is_project_domain=True),
+            _r(keyword_id=2, analysis_date=FIRST, detected_domain="example.com", domain_position=5,
+               domain_source_url="https://example.com/ai", is_project_domain=True),
+            _r(keyword_id=1, analysis_date=LAST, detected_domain="example.com", domain_position=2,
+               domain_source_url="https://example.com/seo", is_project_domain=True),
+            _r(keyword_id=3, analysis_date=LAST, detected_domain="example.com", domain_position=4,
+               domain_source_url="https://example.com/serp", is_project_domain=True),
+            # Competidor comp.com: mantiene kw1, gana kw2
+            _r(keyword_id=1, analysis_date=FIRST, detected_domain="comp.com", domain_position=1,
+               domain_source_url="https://comp.com/a", is_project_domain=False),
+            _r(keyword_id=1, analysis_date=LAST, detected_domain="comp.com", domain_position=1,
+               domain_source_url="https://comp.com/a", is_project_domain=False),
+            _r(keyword_id=2, analysis_date=LAST, detected_domain="comp.com", domain_position=2,
+               domain_source_url="https://comp.com/b", is_project_domain=False),
+        ],
+    }
+
+
+def _service():
+    svc_mod = importlib.import_module("manual_ai.services.statistics_service")
+    return svc_mod.StatisticsService()
+
+
+def test_full_comparison_project_entity(monkeypatch):
+    _patch_db(monkeypatch, _full_scenario())
+    data = _service().get_ai_overview_historical_comparison(1, days=30)
+
+    assert data["comparison_available"] is True
+    assert data["compared_dates"] == {"previous": str(FIRST), "current": str(LAST)}
+    assert data["date_count"] == 4
+    assert data["project_domain"] == "example.com"
+
+    # Entidad 0 = tu dominio
+    proj = data["entities"][0]
+    assert proj["type"] == "project"
+    assert proj["summary"] == {
+        "previous_count": 2,
+        "current_count": 2,
+        "gained_count": 1,
+        "lost_count": 1,
+        "maintained_count": 1,
+    }
+
+    gained = proj["gained"][0]
+    assert gained["keyword"] == "serp"
+    assert gained["position"] == 4
+    assert gained["url"] == "https://example.com/serp"
+
+    lost = proj["lost"][0]
+    assert lost["keyword"] == "ai search"
+    assert lost["previous_position"] == 5
+    assert lost["previous_url"] == "https://example.com/ai"
+
+    kept = proj["maintained"][0]
+    assert kept["keyword"] == "seo tips"
+    assert kept["previous_position"] == 3
+    assert kept["current_position"] == 2
+    assert kept["position_delta"] == -1  # negativo = mejora (sube en ranking)
+    assert kept["url"] == "https://example.com/seo"
+
+
+def test_full_comparison_competitor_entity(monkeypatch):
+    _patch_db(monkeypatch, _full_scenario())
+    data = _service().get_ai_overview_historical_comparison(1, days=30)
+
+    comp = data["entities"][1]
+    assert comp["type"] == "competitor"
+    assert comp["domain"] == "comp.com"
+    assert comp["summary"]["previous_count"] == 1
+    assert comp["summary"]["current_count"] == 2
+    assert comp["summary"]["gained_count"] == 1
+    assert comp["summary"]["lost_count"] == 0
+    assert comp["summary"]["maintained_count"] == 1
+
+    assert comp["gained"][0]["keyword"] == "ai search"
+    assert comp["gained"][0]["url"] == "https://comp.com/b"
+    assert comp["maintained"][0]["keyword"] == "seo tips"
+
+
+def test_single_date_not_enough_history(monkeypatch):
+    scenario = _full_scenario()
+    scenario["dates"] = _r(first_date=LAST, last_date=LAST, date_count=1)
+    _patch_db(monkeypatch, scenario)
+
+    data = _service().get_ai_overview_historical_comparison(1, days=7)
+    assert data["comparison_available"] is False
+    assert data["date_count"] == 1
+    assert data["entities"] == []
+
+
+def test_missing_project_returns_empty(monkeypatch):
+    scenario = _full_scenario()
+    scenario["project"] = None
+    _patch_db(monkeypatch, scenario)
+
+    data = _service().get_ai_overview_historical_comparison(999, days=30)
+    assert data["comparison_available"] is False
+    assert data["entities"] == []
+
+
+def test_normalize_and_match_helpers():
+    mod = importlib.import_module("manual_ai.services._statistics.historical")
+    assert mod._normalize_domain("https://www.Example.com/path") == "example.com"
+    assert mod._normalize_domain(None) == ""
+    assert mod._domains_match("comp.com", "comp.com") is True
+    assert mod._domains_match("blog.comp.com", "comp.com") is True
+    assert mod._domains_match("comp.com", "other.com") is False


### PR DESCRIPTION
## Qué incluye

Promueve a producción la feature **"See historic"** (ya validada en staging): un botón en la cabecera de la tabla *AI Overview Keywords Details* que abre un modal comparando la presencia en AI Overview entre el **primer y el último análisis disponibles** dentro del rango seleccionado (7/30/90 días), para el dominio del proyecto y cada competidor — keywords **ganadas / perdidas / mantenidas** (con delta de posición) y las **URLs afectadas**.

Responde a "mi visibilidad en AIO está cayendo, ¿por qué?": muestra qué keywords te mencionaban hace N días y hoy no, cuáles has ganado, y las URLs implicadas.

## Cambios (4 commits, 10 archivos)

- **Backend** (cero coste SerpAPI; reutiliza `manual_ai_results` + `manual_ai_global_domains`): `_HistoricalMixin` en `services/_statistics/historical.py`, compuesto en `statistics_service.py`; ruta `GET /manual-ai/api/projects/<id>/ai-overview-historical?days=N`.
- **Frontend**: módulo `manual-ai-analytics-historical.js` (patrón mixin Object.assign), botón + modal en el template, `manual-ai-historical.css`.
- **Estilo**: conforme al **brandbook clicandseo** (paleta oficial, Inter Tight, Bio-Lime solo como subrayado de acento, sin pills/badges informativos, formas ultra-soft).
- **Tests**: `tests/test_manual_ai_historical.py` (5).
- `scripts_seed_historical_demo.py`: utilidad de seed **solo staging** (guardada contra prod; inerte, ejecución manual).

## Seguridad / riesgo

- **Sin migración de esquema**: reutiliza tablas y columnas que ya existen en producción (verificado: `domain_source_url`, `is_project_domain`, etc. presentes).
- **Aditivo**: ruta nueva, método nuevo, JS/CSS nuevos, añadidos al template. No modifica lógica ni datos existentes.
- Verificado en staging: deploy vivo, assets 200, endpoint auth-gated, backend correcto en 7/30/90 días, JSON serializable, casos borde seguros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)