### PR TITLE
fix(manual-ai): el modal histórico no reabría tras cerrarlo con Escape/click fuera

### DIFF
--- a/search_console_webapp/static/js/manual-ai/manual-ai-analytics-historical.js
+++ b/search_console_webapp/static/js/manual-ai/manual-ai-analytics-historical.js
@@ -29,14 +29,17 @@ export function openHistoricalComparison() {
     const body = document.getElementById('historicalComparisonBody');
     if (!modal || !body) return;
 
-    // Estado de carga + abrir modal
+    // Estado de carga + abrir modal.
+    // Usamos display inline (flex) como el resto de modales del sistema: el
+    // handler global hideAllModals() (Escape / click fuera) cierra con
+    // style.display='none', que ganaría a la clase .show e impediría reabrir.
     body.innerHTML = `
         <div class="hist-loading">
             <i class="fas fa-spinner fa-spin"></i>
             <p>Loading historical comparison...</p>
         </div>
     `;
-    modal.classList.add('show');
+    modal.style.display = 'flex';
 
     this.loadHistoricalComparison(projectId, days);
 }
@@ -70,7 +73,7 @@ export async function loadHistoricalComparison(projectId, days) {
 
 export function hideHistoricalComparison() {
     const modal = document.getElementById('historicalComparisonModal');
-    if (modal) modal.classList.remove('show');
+    if (modal) modal.style.display = 'none';
     this.destroyHistoricalChart();
     this._historicalData = null;
 }


### PR DESCRIPTION
## Bug

El modal *See historic* se abría correctamente la primera vez, pero tras cerrarlo con **Escape** o **clic en el fondo** no volvía a abrirse nunca más.

**Causa**: el modal se mostraba con la clase `.show` (`.modal-overlay.show { display:flex }`), pero el handler global `hideAllModals()` (Escape / clic fuera) cierra todos los `.modal-overlay` con `style.display='none'` **inline**, que gana en especificidad a la regla de clase → `classList.add('show')` ya no podía volver a mostrarlo.

## Fix

Alinear el modal con la convención del resto del sistema: `style.display='flex'` al abrir y `'none'` al cerrar (en vez de la clase `.show`). El open siempre sobreescribe cualquier `display:none` previo, sin importar cómo se cerró.

Solo frontend, 1 archivo. Verificado el ciclo open → close(Escape/fondo) → reopen → close(X) → reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)