### PR TITLE
Manual AI: alinear panel AIO vs Organic con menciones + paginar rankings a 10

### DIFF
--- a/search_console_webapp/manual_ai/services/_statistics/aio_organic.py
+++ b/search_console_webapp/manual_ai/services/_statistics/aio_organic.py
@@ -89,18 +89,42 @@ class _AioOrganicMixin:
             # dominios extraídos de las URLs (que vienen con/sin www).
             project_domain_norm = _domain_of(f'https://{project_domain}')
 
+            # Selección de fila ALINEADA con el Overview: una sola fila por
+            # keyword (la MÁS RECIENTE del rango), idéntico a
+            # get_project_statistics() en overview.py. Así el panel mira el
+            # mismo día que el contador de "menciones" del Overview y no
+            # diverge por elegir un día distinto de la misma keyword.
+            #
+            # "Citado en AIO" pasa a usar r.domain_mentioned (la MISMA señal
+            # que el Overview: detecta el dominio en referencias oficiales,
+            # en el texto del AI Overview y en listados). Antes este panel
+            # solo miraba el array `references`, perdiendo las menciones en
+            # texto/listado que no llevan link.
+            #
+            # Denominador ("keywords analizadas") = keywords cuya última fila
+            # tiene AI Overview + resultados orgánicos. Ya NO se exige que el
+            # array `references` esté poblado (una mención en texto puede
+            # existir sin referencias formales).
             cur.execute("""
-                SELECT r.keyword,
-                       r.raw_serp_data->'organic_results' AS organic,
-                       r.raw_serp_data->'ai_overview'->'references' AS refs
-                FROM manual_ai_results r
-                WHERE r.project_id = %s
-                  AND r.analysis_date BETWEEN %s AND %s
-                  AND r.has_ai_overview = TRUE
-                  AND jsonb_array_length(COALESCE(r.raw_serp_data->'organic_results', '[]'::jsonb)) > 0
-                  AND jsonb_array_length(COALESCE(r.raw_serp_data->'ai_overview'->'references', '[]'::jsonb)) > 0
-                ORDER BY r.analysis_date DESC, r.id DESC
-            """, (project_id, start_date, end_date))
+                WITH latest AS (
+                    SELECT DISTINCT ON (k.id)
+                        k.id AS keyword_id,
+                        k.keyword,
+                        r.has_ai_overview,
+                        r.domain_mentioned,
+                        r.raw_serp_data->'organic_results' AS organic,
+                        r.raw_serp_data->'ai_overview'->'references' AS refs
+                    FROM manual_ai_keywords k
+                    LEFT JOIN manual_ai_results r ON k.id = r.keyword_id
+                        AND r.analysis_date >= %s AND r.analysis_date <= %s
+                    WHERE k.project_id = %s
+                    ORDER BY k.id, r.analysis_date DESC
+                )
+                SELECT keyword, domain_mentioned, organic, refs
+                FROM latest
+                WHERE has_ai_overview = TRUE
+                  AND jsonb_array_length(COALESCE(organic, '[]'::jsonb)) > 0
+            """, (start_date, end_date, project_id))
             rows = cur.fetchall()
         finally:
             cur.close()
@@ -192,18 +216,21 @@ class _AioOrganicMixin:
             overlap_url_total += n_url_overlap
             overlap_domain_total += n_dom_overlap
 
-            # Cuadrantes del dominio del proyecto (comparación por dominio,
-            # NO por URL exacta: si mi dominio aparece en /pagina-A como
-            # orgánico y en /pagina-B como ref de AIO, para el análisis
-            # SEO/GEO cuenta como "presente en ambos").
+            # Cuadrantes del dominio del proyecto:
+            #   - Orgánico: comparación por dominio (no URL exacta): si mi
+            #     dominio aparece en cualquier resultado orgánico, cuenta.
+            #   - AIO: usa domain_mentioned (referencias + texto + listados),
+            #     la misma señal que el Overview.
             my_in_org = (
                 project_domain_norm in org_dom_set
                 if project_domain_norm else False
             )
-            my_in_aio = (
-                project_domain_norm in ref_dom_set
-                if project_domain_norm else False
-            )
+            # "Citado en AIO" = MISMA señal que el Overview (domain_mentioned),
+            # que cubre referencias oficiales + menciones en texto + listados.
+            # `ref_dom_set` se sigue usando para las stats de overlap y para
+            # aio_refs_count, pero ya NO decide si el dominio cuenta como
+            # citado (eso perdía las menciones de texto sin link).
+            my_in_aio = bool(r['domain_mentioned'])
 
             if my_in_org and my_in_aio:
                 kw_in_both += 1

--- a/search_console_webapp/static/js/manual-ai/manual-ai-analytics-domains.js
+++ b/search_console_webapp/static/js/manual-ai/manual-ai-analytics-domains.js
@@ -133,9 +133,9 @@ export async function loadGlobalDomainsRanking(projectId) {
 
         const data = await response.json();
         
-        // Añadir paginación simple en cliente (20 por página)
+        // Añadir paginación simple en cliente (10 por página)
         const fullList = data.domains || [];
-        const pageSize = 20;
+        const pageSize = 10;
         const state = this._globalDomainsState || { page: 1 };
         const totalPages = Math.max(1, Math.ceil(fullList.length / pageSize));
         state.page = Math.min(state.page, totalPages);

--- a/search_console_webapp/static/js/manual-ai/manual-ai-analytics-urls.js
+++ b/search_console_webapp/static/js/manual-ai/manual-ai-analytics-urls.js
@@ -60,7 +60,7 @@ export async function loadTopUrlsRanking(projectId) {
             } catch (e) {
                 console.error('Error applying filter, showing all URLs:', e);
                 // Apply pagination on error
-                const pageSize = 20;
+                const pageSize = 10;
                 const state = { page: 1 };
                 const totalPages = Math.max(1, Math.ceil(this._allUrlsData.length / pageSize));
                 const paged = this._allUrlsData.slice(0, pageSize);
@@ -71,7 +71,7 @@ export async function loadTopUrlsRanking(projectId) {
         } else {
             console.log('⚪ Filter is inactive, showing all URLs with pagination');
             // Apply pagination
-            const pageSize = 20;
+            const pageSize = 10;
             const state = this._topUrlsState || { page: 1 };
             const totalPages = Math.max(1, Math.ceil(this._allUrlsData.length / pageSize));
             state.page = Math.min(state.page, totalPages);
@@ -121,7 +121,7 @@ export function filterUrlsByDomain(showOnlyMyDomain) {
             if (!project || !project.domain) {
                 console.error('❌ No project or domain found for filtering, showing all URLs');
                 // Reset pagination and render all
-                const pageSize = 20;
+                const pageSize = 10;
                 const state = { page: 1 };
                 const totalPages = Math.max(1, Math.ceil(this._allUrlsData.length / pageSize));
                 const paged = this._allUrlsData.slice(0, pageSize);
@@ -174,7 +174,7 @@ export function filterUrlsByDomain(showOnlyMyDomain) {
     }
     
     // Apply pagination
-    const pageSize = 20;
+    const pageSize = 10;
     const state = this._topUrlsState || { page: 1 };
     const totalPages = Math.max(1, Math.ceil(filteredUrls.length / pageSize));
     state.page = Math.min(state.page, totalPages);
@@ -332,7 +332,7 @@ export function renderTopUrlsPaginator() {
         if (isFilterActive) {
             this.filterUrlsByDomain(true);
         } else {
-            const pageSize = 20;
+            const pageSize = 10;
             const start = (this._topUrlsState.page - 1) * pageSize;
             const paged = fullList.slice(start, start + pageSize);
             this.renderTopUrlsRanking(paged);
@@ -361,7 +361,7 @@ export function renderTopUrlsPaginator() {
         if (isFilterActive) {
             this.filterUrlsByDomain(true);
         } else {
-            const pageSize = 20;
+            const pageSize = 10;
             const start = (this._topUrlsState.page - 1) * pageSize;
             const paged = fullList.slice(start, start + pageSize);
             this.renderTopUrlsRanking(paged);


### PR DESCRIPTION
Dos cambios en Manual AI listos para producción.

## 1. Panel "AI Overview vs Organic Results" alineado con el Overview
El panel detectaba las citas más estrecho que el contador de "menciones" del Overview, así que los cuadrantes no cuadraban (en getquipu.com: 48 citadas vs 50 menciones).

- "Citado en AIO" ahora usa `domain_mentioned` (referencias + texto + listados), no solo el array `references`.
- Misma fila por keyword que `get_project_statistics()` (la más reciente del rango), sin divergir por días distintos.
- Denominador = keywords cuya última fila tiene AI Overview + orgánico (ya no se exige `references` poblado).

**Verificado contra producción (quipu):** citadas = 50, igual que las 50 menciones del Overview.

## 2. Paginación de rankings a 10 filas
"Global AI Overview Domains Ranking" y "Top Mentioned URLs in AI Overview" pasan de 20 a 10 filas por página, reutilizando la paginación Previous/Next existente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)